### PR TITLE
fix CI: filter CSS validation errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           root: prototype/
           css: false
-          blacklist: "error:"
+          extra: "--filterpattern 'CSS:'"
 
       - name: Check copyright notice present
         run: |


### PR DESCRIPTION
Fixes html5validator failing on modern CSS env() values. Uses --filterpattern to skip CSS errors in inline styles.