### PR TITLE
fix workflows: sync-dev and CI validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,10 @@ jobs:
           echo "✅ File size OK (${SIZE} bytes)"
 
       - name: Validate HTML syntax
-        uses: Cyb3r-Jak3/html5validator-action@v7.2.0
-        with:
-          root: prototype/
-          css: false
-          extra: "--filterpattern 'CSS:'"
+        run: |
+          pip install html5validator --quiet
+          html5validator --root prototype/ --ignore-re "CSS:" --log WARNING
+        continue-on-error: false
 
       - name: Check copyright notice present
         run: |

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -17,6 +17,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout dev
+          git checkout -B dev origin/dev
           git merge origin/main --no-edit
           git push origin dev


### PR DESCRIPTION
- sync-dev: use git checkout -B dev origin/dev to fix exit code 128
- ci: replace html5validator GitHub Action with direct pip install to fix Node.js 20 deprecation warning