### PR TITLE
fix sync-dev: add write permissions to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The sync workflow was failing with 403 because GITHUB_TOKEN lacked write permissions. Added permissions: contents: write.