### PR TITLE
fix sync-dev: use force-push reset instead of merge

### DIFF
--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -13,13 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sync dev with main
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -B dev origin/dev
-          git merge origin/main --no-edit
-          git push origin dev
+      - name: Reset dev to main
+        run: git push --force origin origin/main:refs/heads/dev


### PR DESCRIPTION
Root cause: git merge was creating extra merge commits on dev causing permanent 1-ahead/1-behind divergence. Solution: force-push dev to match main exactly after every merge. Safe because all dev commits are already in main at that point.