### PR TITLE
restore sync-dev workflow with correct merge approach

### DIFF
--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -1,0 +1,25 @@
+name: Sync dev with main
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync dev with main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout dev
+          git merge origin/main --no-edit
+          git push origin dev


### PR DESCRIPTION
Recreates sync-dev.yml using simple git checkout dev + merge origin/main + push. This is the standard approach confirmed by colleague. Requires permissions: contents: write for GITHUB_TOKEN to push.