### PR TITLE
fix breadcrumb on rent-efectivo + active nav button background

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -41,7 +41,8 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-siz
 .screen{display:none;padding:10px 13px 90px}
 .screen.active{display:block}
 .nav-bar{display:flex;border-top:.5px solid var(--bd);background:var(--bg0);padding:5px 0 env(safe-area-inset-bottom,5px);flex-shrink:0}
-.nav-item{flex:1;display:flex;flex-direction:column;align-items:center;gap:2px;cursor:pointer;padding:3px 0;border:none;background:none}
+.nav-item{flex:1;display:flex;flex-direction:column;align-items:center;gap:2px;cursor:pointer;padding:3px 0;border:none;background:none;border-radius:8px;transition:background .15s}
+.nav-item.active{background:var(--ac-bg)}
 .nav-label{font-size:9px;color:var(--t2);font-family:inherit}
 .nav-item.active .nav-label{color:var(--ac);font-weight:600}
 .ni-svg *{stroke:var(--t2)}
@@ -631,7 +632,7 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
     <!-- RENT. EFECTIVO (F5) -->
     <div class="screen" id="s-rent-efectivo">
       <div class="qnav" id="qn-rent-efectivo"></div>
-      <div class="breadcrumb"><button class="bc-link" onclick="goTo('s-efectivo')">← Efectivo</button></div>
+      <div class="breadcrumb"><button class="bc-link" onclick="goTo('s-resumen')">← Resumen</button></div>
       <div class="screen-title">Rentabilidad del efectivo</div>
       <div class="period-row">
         <button class="period-btn active" onclick="setREPeriod(this,'1M')">1M</button>


### PR DESCRIPTION
- Breadcrumb in s-rent-efectivo now points to Resumen (not Efectivo) since it's accessed from Resumen quick actions
- Active nav bar button now has --ac-bg background to make it clearly distinguishable