### PR TITLE
fix: feedback tester #3 — lista carteras fuera de Global + nav bar activo

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -42,11 +42,11 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-siz
 .screen.active{display:block}
 .nav-bar{display:flex;border-top:.5px solid var(--bd);background:var(--bg0);padding:5px 0 env(safe-area-inset-bottom,5px);flex-shrink:0}
 .nav-item{flex:1;display:flex;flex-direction:column;align-items:center;gap:2px;cursor:pointer;padding:3px 0;border:none;background:none;border-radius:8px;transition:background .15s}
-.nav-item.active{background:var(--ac-bg);border-bottom:2px solid var(--ac)}
+.nav-item.active{background:var(--ac);border-radius:8px}
 .nav-label{font-size:9px;color:var(--t2);font-family:inherit}
-.nav-item.active .nav-label{color:var(--ac);font-weight:600}
+.nav-item.active .nav-label{color:#fff;font-weight:600}
 .ni-svg *{stroke:var(--t2)}
-.nav-item.active .ni-svg *{stroke:var(--ac)!important}
+.nav-item.active .ni-svg *{stroke:#fff!important}
 .screen-title{font-size:18px;font-weight:700;margin-bottom:13px;margin-top:8px;color:var(--t0)}
 .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:9px;margin-bottom:13px}
 .metric{background:var(--bg1);border-radius:8px;padding:11px}
@@ -322,8 +322,6 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
         <div class="metric"><div class="mlabel">Total invertido</div><div class="mvalue"><span class="amt" id="g-invertido"></span></div></div>
         <div class="metric"><div class="mlabel">Ganancia total</div><div class="mvalue" id="g-ganancia"></div></div>
       </div>
-      <div class="slabel">Carteras activas</div>
-      <div id="lista-carteras"></div>
       <div class="card">
         <div class="card-title" style="margin-bottom:9px">Distribución global por grupo</div>
         <div id="leg-global" style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:8px"></div>


### PR DESCRIPTION
## Summary
- **Global:** eliminado el listado de carteras individuales y su label. La pantalla queda con métricas consolidadas + donut por grupo + donut por divisa — limpio y sin ambigüedad sobre qué cartera es "activa"
- **Nav bar:** botón activo con fondo `var(--ac)` (azul sólido) e icono/label en blanco — contraste inequívoco

## Test plan
- [ ] Global: no aparece lista de carteras, solo métricas y donuts
- [ ] Nav bar: botón activo claramente distinguible del resto
- [ ] Verificar en modo oscuro

🤖 Generated with [Claude Code](https://claude.com/claude-code)