### PR TITLE
fix: título Global — quitar duplicado y reforzar el de topbar

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -298,7 +298,7 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
       </div>
       <span style="font-size:10px;color:var(--t2);flex-shrink:0">▾</span>
     </div>
-    <div id="global-title" style="display:none;flex:1;font-size:14px;font-weight:600;color:var(--t0)">Todas las carteras</div>
+    <div id="global-title" style="display:none;flex:1;font-size:15px;font-weight:700;color:var(--t0)">Todas las carteras</div>
     <button class="tb-btn" onclick="openModal('m-op')">+ Op.</button>
     <button class="tb-btn" onclick="togglePrivacy()" title="Modo privado" style="font-size:15px;padding:5px 8px">👁</button>
     <button class="tb-btn" onclick="goTo('s-ayuda')" title="Ayuda" style="font-size:15px;padding:5px 8px">❓</button>
@@ -316,7 +316,6 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
 
     <!-- GLOBAL -->
     <div class="screen active" id="s-global">
-      <div class="screen-title">Todas las carteras</div>
       <div class="metric-grid">
         <div class="metric"><div class="mlabel">Valor total</div><div class="mvalue"><span class="amt" id="g-valor-total"></span></div><div class="msub" id="g-rent-total"></div></div>
         <div class="metric"><div class="mlabel">Carteras</div><div class="mvalue" id="g-n-carteras"></div></div>


### PR DESCRIPTION
## Summary
- Eliminado screen-title "Todas las carteras" del cuerpo de s-global (duplicado)
- Título en topbar: font-size 14→15px, font-weight 600→700

🤖 Generated with [Claude Code](https://claude.com/claude-code)