### PR TITLE
feat: sombra sutil en cards

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -54,7 +54,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-siz
 .mvalue{font-size:19px;font-weight:700;color:var(--t0)}
 .msub{font-size:11px;margin-top:2px}
 .pos{color:var(--pos)}.neg{color:var(--neg)}
-.card{background:var(--bg0);border:.5px solid var(--bd);border-radius:12px;padding:12px;margin-bottom:10px}
+.card{background:var(--bg0);border:.5px solid var(--bd);border-radius:12px;padding:12px;margin-bottom:10px;box-shadow:0 2px 8px rgba(0,0,0,0.07)}
 .card-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:9px}
 .card-title{font-size:13px;font-weight:600;color:var(--t0)}
 .badge{display:inline-block;padding:2px 7px;border-radius:4px;font-size:11px;font-weight:500}
@@ -112,14 +112,14 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
 .dnd-item.drag-over{background:var(--ac-bg)!important;border-color:var(--ac)!important}
 .drag-handle{display:flex;align-items:center;justify-content:center;width:24px;height:24px;color:var(--t2);cursor:grab;font-size:14px;flex-shrink:0}
 /* ── CUENTA CARD (F9) ──────────────────────────── */
-.cuenta-card{background:var(--bg0);border:.5px solid var(--bd);border-radius:12px;padding:12px;margin-bottom:8px}
+.cuenta-card{background:var(--bg0);border:.5px solid var(--bd);border-radius:12px;padding:12px;margin-bottom:8px;box-shadow:0 2px 8px rgba(0,0,0,0.07)}
 .cuenta-card-header{display:flex;align-items:center;gap:9px;margin-bottom:5px}
 .cuenta-icon{width:34px;height:34px;border-radius:9px;display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;flex-shrink:0}
 .cuenta-actions{display:flex;gap:4px;margin-left:auto}
 .cuenta-actions button{background:none;border:none;cursor:pointer;color:var(--t2);padding:3px 5px;border-radius:5px;font-size:13px}
 .cuenta-actions button:hover{background:var(--bg2);color:var(--t0)}
 /* ── ANOTACIONES (F3) ─────────────────────────── */
-.nota-card{background:var(--bg0);border:.5px solid var(--bd);border-radius:12px;padding:12px;padding-right:70px;margin-bottom:8px;position:relative}
+.nota-card{background:var(--bg0);border:.5px solid var(--bd);border-radius:12px;padding:12px;padding-right:70px;margin-bottom:8px;position:relative;box-shadow:0 2px 8px rgba(0,0,0,0.07)}
 .nota-card:hover{border-color:var(--bd2)}
 .nota-tag{display:inline-flex;padding:2px 7px;border-radius:4px;font-size:10px;font-weight:600;letter-spacing:.04em;margin-right:3px}
 .nota-card-actions{position:absolute;top:10px;right:10px;display:flex;gap:3px;opacity:1}
@@ -144,7 +144,7 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
 .modal{background:var(--bg0);border-radius:18px 18px 0 0;padding:20px;width:100%;max-height:88%;overflow-y:auto}
 .mhdr{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
 .mtitle{font-size:15px;font-weight:700;color:var(--t0)}
-.port-card{border:.5px solid var(--bd);border-radius:12px;padding:12px;margin-bottom:8px;cursor:pointer;background:var(--bg0)}
+.port-card{border:.5px solid var(--bd);border-radius:12px;padding:12px;margin-bottom:8px;cursor:pointer;background:var(--bg0);box-shadow:0 2px 8px rgba(0,0,0,0.07)}
 .port-card:hover{background:var(--bg1)}
 .port-card.active-card{border:1.5px solid var(--ac)}
 .otp-row{display:flex;gap:8px;justify-content:center;margin:18px 0}


### PR DESCRIPTION
## Summary
- `box-shadow: 0 2px 8px rgba(0,0,0,0.07)` añadida a `.card`, `.cuenta-card`, `.nota-card` y `.port-card`
- El borde existente se mantiene para que el modo oscuro siga funcionando correctamente (las sombras negras sobre fondo oscuro desaparecen solas)

## Test plan
- [ ] Cards con profundidad visible en modo claro
- [ ] Modo oscuro sin cambios apreciables (sombra invisible, borde activo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)