### PR TITLE
ci: reactivar sync-dev automático

### DIFF
--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -1,7 +1,9 @@
 name: Sync dev with main
 
 on:
-  workflow_dispatch: # deshabilitado — dev protegida por ruleset, sync manual
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Reactiva el trigger automático en `sync-dev.yml` (push a main)
- Funciona ahora porque el ruleset de dev tiene bypass para Repository admin

## Test plan

- [ ] Mergear este PR a dev
- [ ] Hacer PR dev→main y verificar que el workflow corre automáticamente y dev queda sincronizado

🤖 Generated with [Claude Code](https://claude.com/claude-code)