### PR TITLE
ci: revertir trigger automático sync-dev

### DIFF
--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -1,9 +1,7 @@
 name: Sync dev with main
 
 on:
-  push:
-    branches: [main]
-  workflow_dispatch:
+  workflow_dispatch: # sync manual — ruleset de dev requiere PR para push directo
 
 permissions:
   contents: write


### PR DESCRIPTION
Revierte el trigger push a main — el ruleset de dev impide push directo. Sync queda como workflow_dispatch (manual).