### PR TITLE
docs: esquema de eventos completo (sec 29)

### DIFF
--- a/ESTADO.md
+++ b/ESTADO.md
@@ -2431,11 +2431,29 @@ Todos los eventos comparten estos campos. No se repiten en `properties`.
 - `user_role` — `owner_only`: usa la app en solitario · `shared_owner`: tiene carteras compartidas con otros · `shared_member`: accede a carteras de otro usuario.
 - `country` — inferido de IP en PostHog (Fase 1) o de Supabase en Fase 2. Clave para segmentación geográfica y estrategia de expansión LatAm.
 - `locale` — idioma del dispositivo. Útil para adaptar marketing por variante de español.
-- `age_range` / `gender` — datos demográficos opcionales, recogidos con consentimiento explícito durante el onboarding. `null` si el usuario no los proporcionó. Almacenados en el operacional (`user_demographics`) y propagados a los eventos para segmentación. **Nunca se vinculan a la identidad del usuario en el DWH** — se tratan como atributos estadísticos anónimos. Sujetos a RGPD: el usuario puede modificarlos o eliminarlos en cualquier momento desde Ajustes.
+- `age_range` / `gender` — datos demográficos opcionales recogidos con consentimiento explícito. `null` si el usuario no los proporcionó. Almacenados en el operacional (`user_demographics`) y propagados a los eventos para segmentación. **Nunca se vinculan a la identidad del usuario en el DWH** — se tratan como atributos estadísticos anónimos. Sujetos a RGPD: el usuario puede modificarlos o eliminarlos en cualquier momento desde Ajustes.
 
 > **Regla de oro:** ningún evento incluye tickers, importes ni cantidades. Solo el *qué* y el *contexto mínimo necesario*.
 
-> **Nota legal — datos demográficos:** `age_range` y `gender` son datos personales bajo RGPD aunque estén anonimizados. Su recogida requiere consentimiento explícito, informado y revocable. El texto de consentimiento en el onboarding debe especificar: finalidad estadística, anonimización, ausencia de vinculación con la cuenta, y derecho de supresión.
+> **Nota legal — datos demográficos:** `age_range` y `gender` son datos personales bajo RGPD aunque estén anonimizados. Su recogida requiere consentimiento explícito, informado y revocable. El texto de consentimiento debe especificar: finalidad estadística, anonimización, ausencia de vinculación con la cuenta, y derecho de supresión.
+
+#### Estrategia de solicitud de datos demográficos (progressive profiling)
+
+No se piden en el onboarding — el usuario aún no conoce ni aprecia la app y la tasa de rechazo sería alta. Se solicitan después de una señal clara de valor percibido:
+
+- Tras registrar la 5ª operación
+- Tras la primera semana activa con al menos 3 sesiones
+- Tras visualizar su primera rentabilidad calculada
+
+**Lógica de reintento:**
+
+| Respuesta del usuario | Acción |
+|---|---|
+| Completa el formulario | No volver a preguntar |
+| Cierra sin responder | Reintentar a los 90 días |
+| Responde "prefiero no decirlo" en algún campo | No volver a preguntar nunca — es un no definitivo |
+
+El estado de la solicitud (`demographics_asked_at`, `demographics_declined_permanently`) se almacena en `user_demographics` para controlar cuándo y si se vuelve a mostrar.
 
 ---
 

--- a/ESTADO.md
+++ b/ESTADO.md
@@ -2403,37 +2403,138 @@ Los dos sistemas son independientes — el DWH no interfiere con el rendimiento 
 - Activos más populares por región (útil para marketing localizado)
 - Tipo de suscripción por país
 
-### Esquema de eventos (pendiente de diseñar)
+### Esquema de eventos
 
-Cada acción relevante del usuario genera un evento con estructura:
+#### Estructura base
+
+Todos los eventos comparten estos campos. No se repiten en `properties`.
 
 ```json
 {
-  "event_name": "screen_view",
-  "user_id": "uuid",
-  "session_id": "uuid",
-  "timestamp": "ISO8601",
-  "platform": "ios|android|web",
-  "plan": "free|personal|pro",
-  "properties": { ... }
+  "event_name":   "string",
+  "user_id":      "uuid",
+  "session_id":   "uuid",
+  "timestamp":    "ISO8601",
+  "platform":     "ios | android | web",
+  "device_type":  "iphone | ipad | android_phone | android_tablet | desktop",
+  "plan":         "free | personal | pro",
+  "user_role":    "owner_only | shared_owner | shared_member",
+  "country":      "ES | MX | AR | ...",
+  "locale":       "es-ES | es-MX | es-AR | ...",
+  "properties":   { ... }
 }
 ```
 
-**Eventos a capturar (lista inicial):**
+- `device_type` — tipo de dispositivo dentro de cada plataforma. Permite segmentar iPhone vs iPad, móvil vs tablet Android, escritorio vs móvil web.
+- `user_role` — `owner_only`: usa la app en solitario · `shared_owner`: tiene carteras compartidas con otros · `shared_member`: accede a carteras de otro usuario.
+- `country` — inferido de IP en PostHog (Fase 1) o de Supabase en Fase 2. Clave para segmentación geográfica y estrategia de expansión LatAm.
+- `locale` — idioma del dispositivo. Útil para adaptar marketing por variante de español.
 
-| Evento | Descripción |
-|---|---|
-| `session_start` | Inicio de sesión en la app |
-| `session_end` | Cierre de sesión (con duración) |
-| `screen_view` | Cada pantalla visitada |
-| `feature_used` | Uso de funcionalidad específica |
-| `operation_added` | Nueva operación registrada |
-| `backup_triggered` | Backup ejecutado (manual o gestionado) |
-| `subscription_changed` | Cambio de plan |
-| `share_created` | Cartera compartida |
-| `onboarding_step` | Paso del onboarding completado |
+> **Regla de oro:** ningún evento incluye tickers, importes ni cantidades. Solo el *qué* y el *contexto mínimo necesario*.
 
-Pendiente: definir `properties` específicas por evento y diseñar los modelos dbt.
+---
+
+#### Catálogo de eventos
+
+##### Sesión y navegación
+
+| Evento | Properties | Descripción |
+|---|---|---|
+| `session_start` | `first_time: bool`, `push_source: string\|null` | Apertura de la app. `push_source` indica si viene de una notificación push. |
+| `session_end` | `duration_seconds: int` | Cierre de sesión. |
+| `screen_view` | `screen: string`, `previous_screen: string\|null`, `time_on_prev_ms: int\|null` | Cada cambio de pantalla. Permite calcular tiempo medio por pantalla y flujos de navegación. |
+
+##### Onboarding
+
+| Evento | Properties | Descripción |
+|---|---|---|
+| `onboarding_step_completed` | `step_name: string`, `step_index: int` | Paso del onboarding completado. Permite construir el funnel de activación. |
+| `first_portfolio_created` | `currency: string` | Primera cartera creada — señal de activación. |
+
+##### Operaciones y efectivo
+
+| Evento | Properties | Descripción |
+|---|---|---|
+| `operation_added` | `operation_type: buy\|sell\|dividend\|staking`, `asset_type: stock\|etf\|crypto\|other`, `is_first_for_type: bool` | Nueva operación registrada. `is_first_for_type` indica si es la primera vez que el usuario registra ese tipo de activo. |
+| `operation_cancelled` | `operation_type: string`, `days_since_original: int` | Operación cancelada. `days_since_original` indica si fue una corrección inmediata o tardía. |
+| `cash_movement_added` | `cash_type: deposit\|withdrawal` | Movimiento de efectivo registrado. |
+
+##### Carteras y colaboración
+
+| Evento | Properties | Descripción |
+|---|---|---|
+| `portfolio_created` | `portfolio_index: int` | Nueva cartera creada (1ª, 2ª, 3ª…). |
+| `portfolio_shared` | `role_granted: editor\|viewer` | Cartera compartida con otro usuario. Señal de satisfacción y uso colaborativo. |
+
+##### Backup y suscripción
+
+| Evento | Properties | Descripción |
+|---|---|---|
+| `backup_triggered` | `type: manual\|automatic` | Backup ejecutado. |
+| `subscription_changed` | `from_plan: string`, `to_plan: string`, `direction: upgrade\|downgrade` | Cambio de plan. |
+
+##### Engagement
+
+| Evento | Properties | Descripción |
+|---|---|---|
+| `annotation_created` | — | Anotación global creada. Señal de usuario comprometido. |
+| `privacy_mode_toggled` | `enabled: bool` | Modo privacidad activado/desactivado. |
+| `projection_viewed` | `dca_frequency: monthly\|biweekly\|weekly` | Herramienta de proyección DCA usada. |
+| `content_shared` | — | El usuario comparte contenido de la app (captura de cartera, rentabilidad…). |
+| `referral_shared` | — | El usuario comparte un enlace de referido. |
+
+##### Plataformas externas y canales
+
+| Evento | Properties | Descripción |
+|---|---|---|
+| `external_platform_opened` | `platform_name: string` | Enlace a plataforma externa abierto (broker, banco…). Clave para detectar qué brokers son más populares entre nuestros usuarios — insumo para negociar acuerdos comerciales. |
+| `channel_opened` | `channel_name: string`, `channel_type: youtube\|blog\|podcast` | Canal de aprendizaje abierto. Útil para partnerships con creadores de contenido. |
+| `channel_category_viewed` | `category: string` | Categoría de contenido visitada (value investing, análisis técnico, cripto…). |
+
+##### Notificaciones y valoración
+
+| Evento | Properties | Descripción |
+|---|---|---|
+| `notification_action_taken` | `notification_type: string` | El usuario interactúa con una notificación. Permite medir efectividad de notificaciones promocionales. |
+| `app_rated` | `rating: int (1-5)`, `platform: app_store\|google_play`, `triggered_by: manual\|prompt` | El usuario valora la app. |
+
+##### Errores
+
+| Evento | Properties | Descripción |
+|---|---|---|
+| `error_shown` | `error_type: string`, `screen: string` | Error mostrado al usuario. Útil para detectar fricciones en el flujo. |
+
+---
+
+#### Solicitud de valoración en la app
+
+La valoración nativa (diálogo del sistema dentro de la app, sin salir a la tienda) se implementa en el Prototipo 2 con:
+- **iOS:** `SKStoreReviewController.requestReview()` (StoreKit)
+- **Android:** `In-App Review API` (Google Play)
+
+**Cuándo lanzar el prompt:**
+- Tras registrar la 5ª operación (usuario activo)
+- Tras visualizar rentabilidad positiva por primera vez
+- Tras 7 días de uso con al menos 3 sesiones
+- Nunca más de una vez cada 90 días (límite del sistema iOS)
+
+El evento `app_rated` se dispara siempre que el usuario completa la valoración, independientemente de si usó el prompt o fue a la tienda manualmente.
+
+---
+
+#### Modelos dbt previstos
+
+| Modelo | Capa | Descripción |
+|---|---|---|
+| `stg_events` | staging | Limpieza y tipado de todos los eventos raw. Base para todos los marts. |
+| `dau` | marts | DAU / WAU / MAU calculados desde `session_start`. |
+| `screen_engagement` | marts | Tiempo medio por pantalla desde `screen_view`. Identifica pantallas con mayor retención. |
+| `onboarding_funnel` | marts | Conversión paso a paso desde `onboarding_step_completed`. Detecta dónde abandona el usuario nuevo. |
+| `feature_adoption` | marts | Uso de features por plan y `user_role`. Informa decisiones de producto y pricing. |
+| `subscription_funnel` | marts | Conversión free → personal → pro desde `subscription_changed`. |
+| `platform_popularity` | marts | Ranking de plataformas externas desde `external_platform_opened`. Insumo para negociar acuerdos con brokers. |
+| `content_engagement` | marts | Canales y categorías más consumidos desde `channel_opened` y `channel_category_viewed`. Insumo para partnerships con creadores. |
+| `geo_distribution` | marts | Distribución de usuarios por `country` y `locale`. Informa estrategia de expansión LatAm. |
 
 ### Tratamiento de operaciones canceladas en el DWH
 

--- a/ESTADO.md
+++ b/ESTADO.md
@@ -2421,6 +2421,8 @@ Todos los eventos comparten estos campos. No se repiten en `properties`.
   "user_role":    "owner_only | shared_owner | shared_member",
   "country":      "ES | MX | AR | ...",
   "locale":       "es-ES | es-MX | es-AR | ...",
+  "age_range":    "18-24 | 25-34 | 35-44 | 45-54 | 55+ | null",
+  "gender":       "male | female | other | prefer_not_to_say | null",
   "properties":   { ... }
 }
 ```
@@ -2429,8 +2431,11 @@ Todos los eventos comparten estos campos. No se repiten en `properties`.
 - `user_role` — `owner_only`: usa la app en solitario · `shared_owner`: tiene carteras compartidas con otros · `shared_member`: accede a carteras de otro usuario.
 - `country` — inferido de IP en PostHog (Fase 1) o de Supabase en Fase 2. Clave para segmentación geográfica y estrategia de expansión LatAm.
 - `locale` — idioma del dispositivo. Útil para adaptar marketing por variante de español.
+- `age_range` / `gender` — datos demográficos opcionales, recogidos con consentimiento explícito durante el onboarding. `null` si el usuario no los proporcionó. Almacenados en el operacional (`user_demographics`) y propagados a los eventos para segmentación. **Nunca se vinculan a la identidad del usuario en el DWH** — se tratan como atributos estadísticos anónimos. Sujetos a RGPD: el usuario puede modificarlos o eliminarlos en cualquier momento desde Ajustes.
 
 > **Regla de oro:** ningún evento incluye tickers, importes ni cantidades. Solo el *qué* y el *contexto mínimo necesario*.
+
+> **Nota legal — datos demográficos:** `age_range` y `gender` son datos personales bajo RGPD aunque estén anonimizados. Su recogida requiere consentimiento explícito, informado y revocable. El texto de consentimiento en el onboarding debe especificar: finalidad estadística, anonimización, ausencia de vinculación con la cuenta, y derecho de supresión.
 
 ---
 


### PR DESCRIPTION
## Summary

Diseña y documenta el esquema de eventos de analytics en ESTADO.md sec 29.

**Estructura base** (campos comunes a todos los eventos):
- Añade `device_type` (iphone/ipad/android_phone/tablet/desktop)
- Añade `user_role` (owner_only/shared_owner/shared_member)
- Añade `country` e `locale` para segmentación geográfica LatAm

**Catálogo completo** (22 eventos en 8 categorías):
sesión/navegación, onboarding, operaciones, carteras, backup/suscripción, engagement, plataformas externas/canales, notificaciones/valoración, errores

**Solicitud de valoración nativa:** documentación de StoreKit (iOS) e In-App Review API (Android) con criterios de cuándo lanzar el prompt.

**Modelos dbt previstos:** 9 modelos (stg_events + 8 marts) incluyendo `platform_popularity` para negociación con brokers y `geo_distribution` para expansión LatAm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)