### PR TITLE
docs: WatermelonDB como capa de sync — análisis de dependencia (sec 20)

### DIFF
--- a/ESTADO.md
+++ b/ESTADO.md
@@ -1715,6 +1715,43 @@ Dado que las operaciones son inmutables, la estrategia de conflictos es trivial:
 
 ---
 
+### Pantalla de onboarding — transparencia sobre privacidad y datos
+
+Durante el registro, antes de que el usuario cree su primera cartera, se muestra una pantalla dedicada que explica honestamente cómo funcionan sus datos. El objetivo es generar confianza desde el primer momento y convertir la arquitectura local-first en un argumento de venta emocional.
+
+#### Por qué esta pantalla es importante
+
+- El usuario que viene de competidores cloud asume que sus datos están en un servidor. Hay que romper esa expectativa explícitamente.
+- Ser transparente sobre el riesgo de pérdida de datos (si pierde el móvil) antes de que ocurra genera mucha más confianza que descubrirlo después.
+- El backup opcional presentado como un servicio de valor añadido, no como obligación, refuerza el mensaje de control total.
+
+#### Diseño propuesto
+
+Pantalla de onboarding de paso único, tras el registro y antes de crear la primera cartera. Tono: claro, directo, sin jerga técnica.
+
+**Título:**
+> Tus datos son solo tuyos
+
+**Cuerpo:**
+> portapp guarda tus carteras e inversiones únicamente en este dispositivo. Nadie más puede verlos — ni nosotros.
+>
+> Esto significa que si pierdes el móvil o lo cambias sin hacer una copia, perderías tus datos. Te lo decimos ahora para que lo tengas claro desde el principio.
+>
+> Si quieres, podemos guardar una copia de seguridad cifrada en nuestra nube — solo tú tendrás la clave para descifrarla. Nosotros no podemos leerla. Puedes activarlo ahora o más adelante desde Ajustes.
+
+**Acciones:**
+- Botón principal: `Activar backup seguro` → lleva al flujo de configuración de backup
+- Botón secundario: `Ahora no, solo guardar en mi móvil` → continúa al onboarding
+
+#### Notas de implementación (Prototipo 2)
+
+- La pantalla aparece **una sola vez**, justo después del primer login exitoso
+- Se registra en `user_demographics` o `app_usage` si el usuario activó el backup o lo rechazó
+- Si rechaza el backup, la app recuerda no volver a preguntar hasta que el usuario entre en Ajustes → Backup
+- El evento `onboarding_step_completed` con `step_name: 'privacy_screen'` captura si el usuario llegó a esta pantalla y qué opción eligió (`activated_backup` | `skipped`)
+
+---
+
 ### Plan: Prototipo 2 — validación técnica local-first
 
 El prototipo HTML actual (v6) validó **flujos y UX**. El Prototipo 2 no rehace lo mismo — valida **la arquitectura de datos local y el sync**.

--- a/ESTADO.md
+++ b/ESTADO.md
@@ -1588,7 +1588,7 @@ Importación confirmada por el usuario
 - **Android** — Google Play (React Native + Expo)
 - **Web** — PWA o web app (Expo Web / React Native Web)
 
-Las tres plataformas comparten la misma base de código. El sync entre dispositivos (móvil ↔ web ↔ otro móvil) funciona via Supabase Realtime / PowerSync.
+Las tres plataformas comparten la misma base de código. El sync entre dispositivos (móvil ↔ web ↔ otro móvil) funciona via WatermelonDB + Supabase Edge Function.
 
 ---
 
@@ -1626,7 +1626,7 @@ Apps consolidadas con este modelo: **Linear**, **Obsidian**, **Bear**, **Anytype
 |---|---|---|
 | App | React Native + Expo | Una base de código iOS + Android + web |
 | BD local | Expo SQLite / WatermelonDB | SQLite en el dispositivo, muy rápido, offline total |
-| Sync | Electric SQL o PowerSync | Sincroniza SQLite local ↔ PostgreSQL en nube |
+| Sync | WatermelonDB | Sincroniza SQLite local ↔ PostgreSQL — MIT, sin dependencia de terceros |
 | BD nube (opcional) | PostgreSQL (Supabase) | Solo para sync, no como fuente de verdad |
 | Auth | Supabase Auth | Solo necesaria para sync y licencias |
 | Pagos | Paddle | Sin cambios vs. arquitectura clásica |
@@ -1666,7 +1666,52 @@ SQLite local  ←→  Electric SQL  ←→  PostgreSQL  ←→  Electric SQL  �
 | Multi-dispositivo | Sync opcional — el usuario lo activa si lo necesita |
 | B2B desktop | PWA + sync cubre el caso de uso del asesor en desktop |
 | Migraciones de esquema SQLite | Expo SQLite + sistema de migraciones versionadas (igual que en BD clásica) |
-| Complejidad del sync | Electric SQL / PowerSync abstraen la complejidad — no hay que implementar CRDTs a mano |
+| Complejidad del sync | WatermelonDB abstrae la complejidad — no hay que implementar CRDTs a mano |
+
+---
+
+### Análisis de dependencia de la capa de sync (2026-04-27)
+
+La elección de la librería de sync es la decisión técnica con mayor impacto en la independencia del proyecto a largo plazo.
+
+#### Opciones evaluadas
+
+| Opción | Licencia | Dependencia | Complejidad | Veredicto |
+|---|---|---|---|---|
+| **PowerSync** | Propietaria (free tier) | Alta — si cierran o cambian precios, hay que migrar | Baja (abstrae todo) | ❌ Riesgo de dependencia |
+| **Electric SQL** | Apache 2.0 | Media — open source pero tercero en infraestructura | Baja-Media | ⚠️ Mejor que PowerSync pero aún dependencia |
+| **WatermelonDB** | MIT | **Nula** — open source, tú controlas el sync endpoint | Media | ✅ Recomendado |
+| **Sync propio** | — | Nula — control total | Alta | ⚠️ Solo si el equipo tiene experiencia en sync distribuido |
+
+#### Por qué WatermelonDB es la elección correcta para portapp
+
+**1. Sin dependencia de terceros en la capa crítica**
+WatermelonDB es una librería MIT. El protocolo de sync lo implementas tú en una Supabase Edge Function — código que posees completamente. Si WatermelonDB dejara de mantenerse, el código ya está en tu repo y puedes seguir usándolo o migrarlo.
+
+**2. El modelo de datos de portapp simplifica el sync**
+Los datos de portapp son casi todos **append-only** (las operaciones son inmutables, nunca se editan). Esto elimina prácticamente todos los conflictos de sync — el problema más difícil del sync distribuido. No necesitas CRDTs completos: basta con una cola de inserciones pendientes.
+
+**3. Madurez probada**
+WatermelonDB tiene +10.000 estrellas en GitHub, es usado en producción por Nozbe y Hey.com, y lleva activo desde 2018.
+
+**4. Integración natural con Supabase**
+El endpoint de sync de WatermelonDB es una función HTTP estándar — una Supabase Edge Function con ~100 líneas de código lo cubre.
+
+#### Patrón de sync para portapp
+
+```
+Dispositivo (React Native)          Backend (Supabase)
+WatermelonDB (SQLite local)
+    │
+    ├─ pull: GET /sync?lastPulledAt=...  ──→  Edge Function
+    │                                          lee cambios en PostgreSQL
+    │                                    ←──  devuelve registros nuevos/modificados
+    │
+    └─ push: POST /sync                 ──→  Edge Function
+                                               aplica cambios locales en PostgreSQL
+```
+
+Dado que las operaciones son inmutables, la estrategia de conflictos es trivial: **last-write-wins en inserciones**. No hay ediciones que resolver.
 
 ---
 
@@ -1685,9 +1730,9 @@ El prototipo HTML actual (v6) validó **flujos y UX**. El Prototipo 2 no rehace 
 **Stack:**
 ```
 React Native + Expo
-Expo SQLite (bd local)
-PowerSync o Electric SQL (sync)
-Supabase (auth + PostgreSQL para sync)
+WatermelonDB (bd local + sync)
+Supabase Edge Function (endpoint de sync)
+Supabase Auth + PostgreSQL
 ```
 
 **Criterio de éxito:** si el sync funciona de forma transparente y los datos persisten offline, la arquitectura está validada y se adopta para producción. Si hay demasiada complejidad operativa, se vuelve al cliente-servidor clásico.


### PR DESCRIPTION
## Summary

Actualiza sec 20 de ESTADO.md con la decisión arquitectónica de usar WatermelonDB en lugar de PowerSync/Electric SQL como capa de sync.

- Tabla comparativa de las 4 opciones (PowerSync, Electric SQL, WatermelonDB, sync propio)
- Análisis de por qué WatermelonDB elimina el riesgo de dependencia
- Justificación basada en el modelo append-only de portapp (sin conflictos de edición)
- Diagrama del patrón pull/push con Supabase Edge Function
- Stack del Prototipo 2 actualizado

🤖 Generated with [Claude Code](https://claude.com/claude-code)