### PR TITLE
feat: modo básico/avanzado + proyecciones DCA guardadas

### DIFF
--- a/ESTADO.md
+++ b/ESTADO.md
@@ -140,6 +140,8 @@
 
 > **Nota sobre datos del prototipo:** cotizaciones, tipos de cambio y parte del historial de efectivo son datos hardcodeados en variables JS. No hay integración con APIs externas. El código OTP `123456` es simulado — no valida contra un backend real.
 
+> **Modo básico/avanzado:** las pantallas `s-rentabilidad`, `s-grupos`, `s-rent-efectivo`, `s-indices`, `s-anotaciones` y `s-canales` están ocultas en modo básico. El usuario puede activar el modo avanzado desde Ajustes → Modo de uso. Switch gratuito, sin restricción de plan. Decisión: reducir fricción de onboarding para inversores nuevos sin penalizar a los avanzados. El modo persiste entre sesiones (localStorage).
+
 ---
 
 ## 3. Iteraciones de pulido — estado
@@ -1736,6 +1738,8 @@ Pantalla de onboarding de paso único, tras el registro y antes de crear la prim
 > portapp guarda tus carteras e inversiones únicamente en este dispositivo. Nadie más puede verlos — ni nosotros.
 >
 > Esto significa que si pierdes el móvil o lo cambias sin hacer una copia, perderías tus datos. Te lo decimos ahora para que lo tengas claro desde el principio.
+>
+> La app tiene un **modo básico** ideal para empezar y un **modo avanzado** con herramientas analíticas más potentes (rentabilidad TWR, análisis por grupos, índices…). Puedes cambiar entre ellos cuando quieras, gratis, desde Ajustes.
 >
 > Si quieres, podemos guardar una copia de seguridad cifrada en nuestra nube — solo tú tendrás la clave para descifrarla. Nosotros no podemos leerla. Puedes activarlo ahora o más adelante desde Ajustes.
 

--- a/docs/superpowers/plans/2026-04-27-modo-basico-avanzado-proyecciones.md
+++ b/docs/superpowers/plans/2026-04-27-modo-basico-avanzado-proyecciones.md
@@ -1,0 +1,406 @@
+# Modo básico/avanzado + Proyecciones DCA guardadas — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Añadir un switch básico/avanzado gratuito que oculta pantallas analíticas complejas, y convertir la calculadora DCA en una herramienta que guarda múltiples proyecciones por cartera.
+
+**Architecture:** Todo en `prototype/index.html`. El modo se persiste en `localStorage`. Las pantallas avanzadas se ocultan del nav y del quick nav mediante CSS y filtrado JS. Las proyecciones son un array en memoria por cartera.
+
+**Tech Stack:** HTML + CSS + Vanilla JS. Sin framework, sin build.
+
+---
+
+## Archivo afectado
+
+- Modificar: `prototype/index.html`
+- Modificar: `ESTADO.md`
+
+---
+
+## Observaciones críticas del codebase
+
+- El nav bar inferior tiene 8 botones: `nav-global`, `nav-resumen`, `nav-cartera`, `nav-efectivo`, `nav-ops`, `nav-proyeccion`, `nav-indices`, `nav-settings`. **Solo `nav-indices` es una pantalla avanzada en el nav bar**. Los demás (rentabilidad, grupos, etc.) no están en el nav bar — solo en el quick nav.
+- `renderQN()` (línea ~1230) genera el quick nav dinámicamente desde `SL`. Hay que filtrar las pantallas avanzadas cuando `appMode === 'basic'`.
+- `goTo()` (línea ~1211) no tiene guard de modo — hay que añadirlo.
+- Settings empieza en línea ~525 con la sección "Interfaz".
+
+---
+
+## Task 1: Variables de estado y constante ADVANCED_SCREENS
+
+**Files:**
+- Modify: `prototype/index.html`
+
+- [ ] **Step 1: Añadir `appMode` al bloque de estado (línea ~1128)**
+
+Buscar:
+```js
+let notas=['Tesis: largo plazo DCA sobre índices globales.'],nextId=31,privacyOn=false,opsFilter='todas',opsLimit='20',lastBackupDate=null;
+```
+
+Cambiar a:
+```js
+let notas=['Tesis: largo plazo DCA sobre índices globales.'],nextId=31,privacyOn=false,opsFilter='todas',opsLimit='20',lastBackupDate=null,appMode=localStorage.getItem('appMode')||'basic';
+```
+
+- [ ] **Step 2: Añadir constante `ADVANCED_SCREENS` junto a `SCREENS` y `SL` (línea ~1208)**
+
+Buscar:
+```js
+const SCREENS=['s-global','s-resumen',...];
+```
+
+Añadir ANTES de esa línea:
+```js
+const ADVANCED_SCREENS=['s-rentabilidad','s-grupos','s-rent-efectivo','s-indices','s-anotaciones','s-canales'];
+```
+
+- [ ] **Step 3: Verificar**
+
+Abrir en navegador, no debe haber errores en consola.
+
+---
+
+## Task 2: Función `applyAppMode()` + clase `nav-advanced` en nav bar
+
+**Files:**
+- Modify: `prototype/index.html`
+
+- [ ] **Step 1: Añadir clase `nav-advanced` al botón `nav-indices` (línea ~781)**
+
+Buscar:
+```html
+<button class="nav-item" id="nav-indices" onclick="goTo('s-indices',this)">
+```
+
+Cambiar a:
+```html
+<button class="nav-item nav-advanced" id="nav-indices" onclick="goTo('s-indices',this)">
+```
+
+- [ ] **Step 2: Añadir función `applyAppMode()` después de `toggleDark()` (línea ~1204)**
+
+Buscar:
+```js
+function toggleDark(){document.documentElement.classList.toggle('dark');document.getElementById('dark-chk').checked=document.documentElement.classList.contains('dark');reCharts();}
+```
+
+Añadir a continuación:
+```js
+function applyAppMode(){
+  const adv=appMode==='advanced';
+  document.querySelectorAll('.nav-advanced').forEach(el=>el.style.display=adv?'':'none');
+  const chk=document.getElementById('advanced-chk');
+  if(chk)chk.checked=adv;
+}
+```
+
+- [ ] **Step 3: Verificar**
+
+Abrir en navegador. `applyAppMode()` debe poder llamarse desde consola sin errores.
+
+---
+
+## Task 3: Toggle en Settings + función `toggleAppMode()`
+
+**Files:**
+- Modify: `prototype/index.html`
+
+- [ ] **Step 1: Añadir sección "Modo de uso" al inicio de `s-settings` (línea ~526)**
+
+Buscar:
+```html
+<div class="screen" id="s-settings">
+      <div class="screen-title">Ajustes</div>
+      <div class="slabel" style="margin-bottom:7px">Interfaz</div>
+```
+
+Cambiar a:
+```html
+<div class="screen" id="s-settings">
+      <div class="screen-title">Ajustes</div>
+      <div class="slabel" style="margin-bottom:7px">Modo de uso</div>
+      <div class="card">
+        <div class="dr">
+          <div><div class="dk">Modo avanzado</div><div style="font-size:11px;color:var(--t1)">Rentabilidad TWR, grupos, índices y más</div></div>
+          <input type="checkbox" id="advanced-chk" style="width:auto" onchange="toggleAppMode(this.checked)">
+        </div>
+      </div>
+      <div class="slabel" style="margin-top:12px;margin-bottom:7px">Interfaz</div>
+```
+
+- [ ] **Step 2: Añadir función `toggleAppMode()` junto a `applyAppMode()` (línea ~1205)**
+
+Añadir después de `applyAppMode()`:
+```js
+function toggleAppMode(adv){appMode=adv?'advanced':'basic';localStorage.setItem('appMode',appMode);applyAppMode();}
+```
+
+- [ ] **Step 3: Llamar `applyAppMode()` en la inicialización**
+
+Buscar el bloque de inicialización — buscar `goTo('s-global')` en el arranque de la app (línea ~1170 aproximadamente) o el evento `DOMContentLoaded`. Añadir `applyAppMode();` justo antes de la primera llamada a `goTo`.
+
+Si no hay un punto de inicialización claro, añadir al final del `<script>`, justo antes del cierre `</script>`:
+```js
+applyAppMode();
+```
+
+- [ ] **Step 4: Verificar**
+
+Abrir en navegador → ir a Ajustes → activar "Modo avanzado" → verificar que `nav-indices` aparece en el nav bar. Desactivar → verificar que desaparece. Recargar página → verificar que el estado persiste.
+
+---
+
+## Task 4: Filtrar pantallas avanzadas en `renderQN()`
+
+**Files:**
+- Modify: `prototype/index.html`
+
+- [ ] **Step 1: Modificar `renderQN()` para filtrar según `appMode` (línea ~1230)**
+
+Buscar:
+```js
+function renderQN(cur){['resumen','cartera','efectivo','ops','proyeccion','indices','notif','plataformas','rentabilidad','grupos','rent-efectivo','anotaciones','canales'].forEach(k=>{const el=document.getElementById('qn-'+k);if(!el)return;el.innerHTML=Object.entries(SL).filter(([id])=>id!==cur&&id!=='s-global'&&id!=='s-settings'&&id!=='s-perfil'&&id!=='s-ayuda'&&id!=='s-anotaciones').map(([id,l])=>`<button class="qbtn" onclick="goTo('${id}')">${l}</button>`).join('');});}
+```
+
+Cambiar a:
+```js
+function renderQN(cur){['resumen','cartera','efectivo','ops','proyeccion','indices','notif','plataformas','rentabilidad','grupos','rent-efectivo','anotaciones','canales'].forEach(k=>{const el=document.getElementById('qn-'+k);if(!el)return;el.innerHTML=Object.entries(SL).filter(([id])=>id!==cur&&id!=='s-global'&&id!=='s-settings'&&id!=='s-perfil'&&id!=='s-ayuda'&&id!=='s-anotaciones'&&(appMode==='advanced'||!ADVANCED_SCREENS.includes(id))).map(([id,l])=>`<button class="qbtn" onclick="goTo('${id}')">${l}</button>`).join('');});}
+```
+
+- [ ] **Step 2: Verificar**
+
+En modo básico, navegar a Resumen → el quick nav no debe mostrar Rentabilidad, Grupos, Índices, etc. En modo avanzado, deben aparecer.
+
+---
+
+## Task 5: Guard en `goTo()` para pantallas avanzadas
+
+**Files:**
+- Modify: `prototype/index.html`
+
+- [ ] **Step 1: Añadir guard al inicio de `goTo()` (línea ~1211)**
+
+Buscar el inicio de `goTo`:
+```js
+function goTo(sid,btn){SCREENS.forEach(s=>document.getElementById(s).classList.remove('active'));
+```
+
+Cambiar a:
+```js
+function goTo(sid,btn){if(appMode==='basic'&&ADVANCED_SCREENS.includes(sid)){sid='s-global';btn=null;}SCREENS.forEach(s=>document.getElementById(s).classList.remove('active'));
+```
+
+- [ ] **Step 2: Verificar**
+
+Con modo básico activo, intentar `goTo('s-rentabilidad')` desde la consola del navegador → debe navegar a `s-global`.
+
+- [ ] **Step 3: Commit de todo lo anterior (Tasks 1-5)**
+
+```bash
+git add prototype/index.html
+git commit -m "feat: modo básico/avanzado con switch en ajustes y persistencia localStorage"
+```
+
+---
+
+## Task 6: Estado y datos para proyecciones DCA
+
+**Files:**
+- Modify: `prototype/index.html`
+
+- [ ] **Step 1: Añadir variables `proyecciones` y `proyId` al bloque de estado (línea ~1128)**
+
+Buscar la línea de estado ya modificada en Task 1:
+```js
+let notas=[...],nextId=31,privacyOn=false,opsFilter='todas',opsLimit='20',lastBackupDate=null,appMode=localStorage.getItem('appMode')||'basic';
+```
+
+Cambiar a:
+```js
+let notas=[...],nextId=31,privacyOn=false,opsFilter='todas',opsLimit='20',lastBackupDate=null,appMode=localStorage.getItem('appMode')||'basic',proyecciones=[],proyId=1;
+```
+
+- [ ] **Step 2: Verificar**
+
+Abrir en navegador, no debe haber errores en consola.
+
+---
+
+## Task 7: HTML de la pantalla `s-proyeccion`
+
+**Files:**
+- Modify: `prototype/index.html`
+
+- [ ] **Step 1: Reemplazar el título estático y añadir contenedor de lista (línea ~464)**
+
+Buscar:
+```html
+<div class="screen" id="s-proyeccion">
+      <div class="qnav" id="qn-proyeccion"></div>
+      <div class="screen-title">Proyección DCA</div>
+      <div class="card">
+```
+
+Cambiar a:
+```html
+<div class="screen" id="s-proyeccion">
+      <div class="qnav" id="qn-proyeccion"></div>
+      <div class="screen-title" id="proy-titulo">Proyección DCA</div>
+      <div id="proy-list" style="display:none;margin-bottom:10px"></div>
+      <div class="card">
+```
+
+- [ ] **Step 2: Añadir botón "Guardar proyección" después del botón Calcular (línea ~477)**
+
+Buscar:
+```html
+<button class="btn btn-p" onclick="calcProy()">Calcular</button>
+```
+
+Cambiar a:
+```html
+<button class="btn btn-p" onclick="calcProy()">Calcular</button>
+        <button class="btn" style="margin-top:8px;width:100%" onclick="saveProy()">Guardar proyección</button>
+```
+
+- [ ] **Step 3: Verificar HTML**
+
+Abrir en navegador. La pantalla DCA debe mostrar el título y el botón sin errores visuales.
+
+---
+
+## Task 8: Funciones de proyecciones DCA
+
+**Files:**
+- Modify: `prototype/index.html`
+
+- [ ] **Step 1: Añadir las cuatro funciones después de `calcProy()` (buscar `function calcProy`)**
+
+Añadir después de la función `calcProy` completa:
+
+```js
+function renderProyList(){
+  const lista=proyecciones.filter(p=>p.cartera===activeId);
+  const el=document.getElementById('proy-list');
+  const tit=document.getElementById('proy-titulo');
+  const cart=carteras.find(c=>c.id===activeId);
+  if(tit)tit.textContent=lista.length?`Proyecciones — ${cart?.nombre||''}`: 'Proyección DCA';
+  if(!el)return;
+  el.style.display=lista.length?'block':'none';
+  el.innerHTML=lista.length?`<div class="card" style="padding:10px"><div class="card-title" style="margin-bottom:8px">Proyecciones guardadas</div>`+
+    lista.map(p=>`<div class="dr" style="gap:8px;padding:4px 0"><span class="tag" onclick="loadProy(${p.id})" style="cursor:pointer;flex:1">${p.nombre}</span><button class="btn-icon" onclick="deleteProy(${p.id})" style="color:var(--neg);font-size:14px">🗑</button></div>`).join('')+
+    `</div>`:'';
+}
+function saveProy(){
+  const nombre=prompt('Nombre de esta proyección:');
+  if(!nombre||!nombre.trim())return;
+  proyecciones.push({id:proyId++,cartera:activeId,nombre:nombre.trim(),
+    amt:parseFloat(document.getElementById('dca-amt').value)||300,
+    freq:document.getElementById('dca-freq').value,
+    rate:parseFloat(document.getElementById('dca-rate').value)||8,
+    years:parseInt(document.getElementById('dca-years').value)||10});
+  renderProyList();
+  showToast('Proyección guardada ✓');
+}
+function loadProy(id){
+  const p=proyecciones.find(x=>x.id===id);
+  if(!p)return;
+  document.getElementById('dca-amt').value=p.amt;
+  document.getElementById('dca-freq').value=p.freq;
+  document.getElementById('dca-rate').value=p.rate;
+  document.getElementById('dca-years').value=p.years;
+  calcProy();
+}
+function deleteProy(id){
+  if(!confirm('¿Eliminar esta proyección?'))return;
+  proyecciones=proyecciones.filter(x=>x.id!==id);
+  renderProyList();
+}
+```
+
+- [ ] **Step 2: Llamar `renderProyList()` en `goTo('s-proyeccion')`**
+
+Buscar en `goTo()` el bloque que maneja `s-proyeccion`:
+```js
+else if(sid==='s-proyeccion')
+```
+
+Añadir `renderProyList();` en ese bloque (junto a cualquier otra función de render que haya allí, o añadir el caso si no existe):
+```js
+else if(sid==='s-proyeccion'){calcProy();renderProyList();}
+```
+
+Verificar primero qué hace el caso actual de `s-proyeccion` en `goTo` antes de modificarlo — puede tener ya un `calcProy()`.
+
+- [ ] **Step 3: Verificar flujo completo**
+
+1. Ir a pantalla DCA
+2. Calcular una proyección con valores por defecto
+3. Pulsar "Guardar proyección" → introducir nombre "Escenario conservador"
+4. Verificar que aparece la tarjeta con el nombre
+5. Cambiar valores y guardar otra → "Escenario optimista"
+6. Pulsar "Escenario conservador" → verificar que carga esos valores y recalcula
+7. Eliminar "Escenario optimista" → verificar que desaparece
+8. Cambiar de cartera → verificar que las proyecciones son distintas por cartera
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prototype/index.html
+git commit -m "feat: proyecciones DCA guardadas por cartera"
+```
+
+---
+
+## Task 9: Actualizar ESTADO.md
+
+**Files:**
+- Modify: `ESTADO.md`
+
+- [ ] **Step 1: Añadir nota sobre modo básico/avanzado en sec 2 (pantallas implementadas)**
+
+Buscar la sección `## 2. Pantallas implementadas en el prototipo` en ESTADO.md y añadir al final de la tabla o después de ella:
+
+```markdown
+> **Modo básico/avanzado:** las pantallas `s-rentabilidad`, `s-grupos`, `s-rent-efectivo`, `s-indices`, `s-anotaciones` y `s-canales` están ocultas en modo básico. El usuario puede activar el modo avanzado desde Ajustes. Switch gratuito, sin restricción de plan. Decisión: reducir fricción de onboarding para inversores nuevos sin penalizar a los avanzados.
+```
+
+- [ ] **Step 2: Actualizar pantalla onboarding en sec 20**
+
+Buscar en sec 20 el texto de la pantalla de onboarding. En el **Cuerpo**, añadir un párrafo entre el de pérdida de datos y el de backup:
+
+```
+> La app tiene un **modo básico** ideal para empezar y un **modo avanzado** con herramientas analíticas más potentes (rentabilidad TWR, análisis por grupos, índices…). Puedes cambiar entre ellos cuando quieras, gratis, desde Ajustes.
+```
+
+- [ ] **Step 3: Commit todo**
+
+```bash
+git add prototype/index.html ESTADO.md
+git commit -m "docs: modo básico/avanzado documentado en ESTADO secs 2 y 20"
+```
+
+---
+
+## Task 10: PR a dev
+
+- [ ] **Step 1: Merge origin/main antes del PR**
+
+```bash
+git fetch origin
+git merge origin/main --no-edit
+git push
+```
+
+- [ ] **Step 2: Crear PR a dev**
+
+```bash
+gh pr create --base dev --title "feat: modo básico/avanzado + proyecciones DCA guardadas" --body "Implementa spec aprobado en docs/superpowers/specs/2026-04-27-modo-basico-avanzado-proyecciones-design.md
+
+- Switch modo básico/avanzado en Ajustes, persistido en localStorage. Modo básico por defecto.
+- Pantallas avanzadas (rentabilidad, grupos, índices, anotaciones, canales) ocultas en nav y quick nav en modo básico.
+- Guard en goTo() redirige a Global si se intenta navegar a pantalla avanzada en modo básico.
+- Proyecciones DCA: guardar, cargar y eliminar escenarios por cartera activa.
+- ESTADO.md actualizado con nota en sec 2 y texto de onboarding en sec 20."
+```

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -524,7 +524,14 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
     <!-- SETTINGS -->
     <div class="screen" id="s-settings">
       <div class="screen-title">Ajustes</div>
-      <div class="slabel" style="margin-bottom:7px">Interfaz</div>
+      <div class="slabel" style="margin-bottom:7px">Modo de uso</div>
+      <div class="card">
+        <div class="dr">
+          <div><div class="dk">Modo avanzado</div><div style="font-size:11px;color:var(--t1)">Rentabilidad TWR, grupos, índices y más</div></div>
+          <input type="checkbox" id="advanced-chk" style="width:auto" onchange="toggleAppMode(this.checked)">
+        </div>
+      </div>
+      <div class="slabel" style="margin-top:12px;margin-bottom:7px">Interfaz</div>
       <div class="card">
         <div class="dr"><span class="dk">Modo oscuro</span><input type="checkbox" id="dark-chk" style="width:auto" onchange="toggleDark()"></div>
         <div class="dr"><span class="dk">Tamaño de fuente</span><select style="width:110px;padding:4px" onchange="setFontSize(this.value)"><option value="fs-sm">Pequeño</option><option value="fs-md" selected>Normal</option><option value="fs-lg">Grande</option><option value="fs-xl">Muy grande</option></select></div>
@@ -778,7 +785,7 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
     <button class="nav-item" id="nav-efectivo" onclick="goTo('s-efectivo',this)"><svg class="ni-svg" width="18" height="18" viewBox="0 0 18 18" fill="none"><rect x="1" y="4" width="16" height="10" rx="2" stroke-width="1.3"/><path d="M1 7h16" stroke-width="1.3"/><circle cx="5" cy="11" r="1" fill="var(--t2)" stroke="none"/></svg><span class="nav-label">Efectivo</span></button>
     <button class="nav-item" id="nav-ops" onclick="goTo('s-ops',this)"><svg class="ni-svg" width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M3 5h12M3 9h8M3 13h10" stroke-width="1.3" stroke-linecap="round"/></svg><span class="nav-label">Ops.</span></button>
     <button class="nav-item" id="nav-proyeccion" onclick="goTo('s-proyeccion',this)"><svg class="ni-svg" width="18" height="18" viewBox="0 0 18 18" fill="none"><polyline points="1,14 6,8 10,11 17,3" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="nav-label">DCA</span></button>
-    <button class="nav-item" id="nav-indices" onclick="goTo('s-indices',this)"><svg class="ni-svg" width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="9" r="7" stroke-width="1.3"/><line x1="9" y1="2" x2="9" y2="16" stroke-width="1.3"/><line x1="2" y1="9" x2="16" y2="9" stroke-width="1.3"/></svg><span class="nav-label">Mercado</span></button>
+    <button class="nav-item nav-advanced" id="nav-indices" onclick="goTo('s-indices',this)"><svg class="ni-svg" width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="9" r="7" stroke-width="1.3"/><line x1="9" y1="2" x2="9" y2="16" stroke-width="1.3"/><line x1="2" y1="9" x2="16" y2="9" stroke-width="1.3"/></svg><span class="nav-label">Mercado</span></button>
     <button class="nav-item" id="nav-settings" onclick="goTo('s-settings',this)"><svg class="ni-svg" width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="9" r="2.5" stroke-width="1.3"/><path d="M9 1v2M9 15v2M1 9h2M15 9h2M3.2 3.2l1.4 1.4M13.4 13.4l1.4 1.4M3.2 14.8l1.4-1.4M13.4 4.6l1.4-1.4" stroke-width="1.3" stroke-linecap="round"/></svg><span class="nav-label">Ajustes</span></button>
   </div>
 </div>
@@ -1125,7 +1132,7 @@ const plats=[
   {nombre:'Coinbase',url:'https://www.coinbase.com',cat:'Cripto',color:'#0052ff',icon:'CB'},
 ];
 const idxData={'FTSE All-World':{ytd:'+8,2%',y1:'+12,4%',pe:'18,4x',div:'1,8%',n:'3.700+',desc:'Renta variable global desarrollada + emergente'},'MSCI World':{ytd:'+8,7%',y1:'+13,1%',pe:'19,8x',div:'1,5%',n:'1.400+',desc:'Renta variable mercados desarrollados'},'S&P 500':{ytd:'+9,1%',y1:'+14,2%',pe:'21,2x',div:'1,3%',n:'500',desc:'500 mayores empresas de EE.UU.'}};
-let notas=['Tesis: largo plazo DCA sobre índices globales.'],nextId=31,privacyOn=false,opsFilter='todas',opsLimit='20',lastBackupDate=null;
+let notas=['Tesis: largo plazo DCA sobre índices globales.'],nextId=31,privacyOn=false,opsFilter='todas',opsLimit='20',lastBackupDate=null,appMode=localStorage.getItem('appMode')||'basic';
 const canales=[
   {id:'ch1',nombre:'Fondos Indexados',ini:'FI',color:'#4a7fa5',cat:'ETFs',desc:'Inversión pasiva en índices globales, ETFs y estrategias de largo plazo.',url:'#',fav:false,dest:true},
   {id:'ch2',nombre:'Value School',ini:'VS',color:'#4a8c6f',cat:'Value',desc:'Value investing, análisis fundamental y filosofía de inversión a largo plazo.',url:'#',fav:true,dest:false},
@@ -1202,13 +1209,16 @@ document.addEventListener('visibilitychange',()=>{
 });
 function togglePrivacy(){privacyOn=!privacyOn;document.getElementById('device').classList.toggle('masked',privacyOn);document.getElementById('privacy-bar').classList.toggle('on',privacyOn);}
 function toggleDark(){document.documentElement.classList.toggle('dark');document.getElementById('dark-chk').checked=document.documentElement.classList.contains('dark');reCharts();}
+function applyAppMode(){const adv=appMode==='advanced';document.querySelectorAll('.nav-advanced').forEach(el=>el.style.display=adv?'':'none');const chk=document.getElementById('advanced-chk');if(chk)chk.checked=adv;}
+function toggleAppMode(adv){appMode=adv?'advanced':'basic';localStorage.setItem('appMode',appMode);applyAppMode();}
 function setFontSize(cls){['fs-sm','fs-md','fs-lg','fs-xl'].forEach(c=>document.documentElement.classList.remove(c));document.documentElement.classList.add(cls);}
 function togglePwd(id,btn){const el=document.getElementById(id);el.type=el.type==='password'?'text':'password';btn.style.opacity=el.type==='text'?'1':'0.5';}
 function reCharts(){const a=id=>document.getElementById(id).classList.contains('active');if(a('s-global'))requestAnimationFrame(()=>requestAnimationFrame(renderGlobal));if(a('s-resumen'))requestAnimationFrame(()=>requestAnimationFrame(()=>{renderCR();renderHistorial('1S');}));if(a('s-rentabilidad'))requestAnimationFrame(()=>requestAnimationFrame(renderRentabilidad));if(a('s-grupos'))requestAnimationFrame(()=>requestAnimationFrame(renderGruposCapital));}
+const ADVANCED_SCREENS=['s-rentabilidad','s-grupos','s-rent-efectivo','s-indices','s-anotaciones','s-canales'];
 const SCREENS=['s-global','s-resumen','s-cartera','s-efectivo','s-ops','s-proyeccion','s-indices','s-notif','s-plataformas','s-settings','s-rentabilidad','s-grupos','s-perfil','s-rent-efectivo','s-anotaciones','s-canales','s-ayuda'];
 const SL={'s-global':'Global','s-resumen':'Resumen','s-cartera':'Cartera','s-efectivo':'Efectivo','s-ops':'Ops.','s-proyeccion':'Proy.','s-indices':'Índices','s-notif':'Avisos','s-plataformas':'Links','s-settings':'Ajustes','s-rentabilidad':'Rentab.','s-grupos':'Grupos','s-perfil':'Perfil','s-rent-efectivo':'Rent.Ef.','s-anotaciones':'Notas','s-canales':'Aprende','s-ayuda':'Ayuda'};
 const NM={'s-global':'nav-global','s-resumen':'nav-resumen','s-cartera':'nav-cartera','s-efectivo':'nav-efectivo','s-ops':'nav-ops','s-proyeccion':'nav-proyeccion','s-indices':'nav-indices','s-settings':'nav-settings'};
-function goTo(sid,btn){SCREENS.forEach(s=>document.getElementById(s).classList.remove('active'));document.getElementById(sid).classList.add('active');document.querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active'));const nb=btn||document.getElementById(NM[sid]);if(nb)nb.classList.add('active');closeAllModals();renderQN(sid);const sw=document.getElementById('sw');if(sw)sw.scrollTop=0;const ps=document.getElementById('port-sel');const gt=document.getElementById('global-title');if(ps)ps.style.display=sid==='s-global'?'none':'flex';if(gt)gt.style.display=sid==='s-global'?'block':'none';
+function goTo(sid,btn){if(appMode==='basic'&&ADVANCED_SCREENS.includes(sid)){sid='s-global';btn=null;}SCREENS.forEach(s=>document.getElementById(s).classList.remove('active'));document.getElementById(sid).classList.add('active');document.querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active'));const nb=btn||document.getElementById(NM[sid]);if(nb)nb.classList.add('active');closeAllModals();renderQN(sid);const sw=document.getElementById('sw');if(sw)sw.scrollTop=0;const ps=document.getElementById('port-sel');const gt=document.getElementById('global-title');if(ps)ps.style.display=sid==='s-global'?'none':'flex';if(gt)gt.style.display=sid==='s-global'?'block':'none';
   if(sid==='s-global'){requestAnimationFrame(()=>requestAnimationFrame(renderGlobal));}
   else if(sid==='s-resumen'){renderResumen();requestAnimationFrame(()=>requestAnimationFrame(()=>{renderCR();renderHistorial('1S');}));}
   else if(sid==='s-cartera')renderCartera();
@@ -1227,7 +1237,7 @@ function goTo(sid,btn){SCREENS.forEach(s=>document.getElementById(s).classList.r
   else if(sid==='s-ayuda')renderAyuda();
   else if(sid==='s-proyeccion'){const el=document.getElementById('dca-base-display');if(el)el.textContent=fe(cV(activeId)||0);}
 }
-function renderQN(cur){['resumen','cartera','efectivo','ops','proyeccion','indices','notif','plataformas','rentabilidad','grupos','rent-efectivo','anotaciones','canales'].forEach(k=>{const el=document.getElementById('qn-'+k);if(!el)return;el.innerHTML=Object.entries(SL).filter(([id])=>id!==cur&&id!=='s-global'&&id!=='s-settings'&&id!=='s-perfil'&&id!=='s-ayuda'&&id!=='s-anotaciones').map(([id,l])=>`<button class="qbtn" onclick="goTo('${id}')">${l}</button>`).join('');});}
+function renderQN(cur){['resumen','cartera','efectivo','ops','proyeccion','indices','notif','plataformas','rentabilidad','grupos','rent-efectivo','anotaciones','canales'].forEach(k=>{const el=document.getElementById('qn-'+k);if(!el)return;el.innerHTML=Object.entries(SL).filter(([id])=>id!==cur&&id!=='s-global'&&id!=='s-settings'&&id!=='s-perfil'&&id!=='s-ayuda'&&id!=='s-anotaciones'&&(appMode==='advanced'||!ADVANCED_SCREENS.includes(id))).map(([id,l])=>`<button class="qbtn" onclick="goTo('${id}')">${l}</button>`).join('');});}
 function renderAyuda(){}
 function openModal(id){document.getElementById(id).classList.add('open');if(id==='m-portfolios')renderPortList();if(id==='m-op'||id==='m-efectivo')fillCS();}
 function closeModal(id){document.getElementById(id).classList.remove('open');}
@@ -1946,6 +1956,7 @@ function renderRentEfectivo(){
   document.getElementById('tb-re').innerHTML=ingresos.map(e=>`<tr><td>${e.fecha.slice(5)}</td><td><span class="badge b-teal">${e.tipo}</span></td><td>${e.broker}</td><td class="pos"><span class="amt">+€${e.importe.toLocaleString('es-ES')}</span></td></tr>`).join('')||'<tr><td colspan="4" style="color:var(--t1)">Sin rendimientos en este período</td></tr>';
 }
 document.getElementById('op-date').value=new Date().toISOString().split('T')[0];
+applyAppMode();
 </script>
 </body>
 </html>

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -463,7 +463,8 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
     <!-- PROYECCIÓN -->
     <div class="screen" id="s-proyeccion">
       <div class="qnav" id="qn-proyeccion"></div>
-      <div class="screen-title">Proyección DCA</div>
+      <div class="screen-title" id="proy-titulo">Proyección DCA</div>
+      <div id="proy-list" style="display:none;margin-bottom:10px"></div>
       <div class="card">
         <div style="font-size:11px;color:var(--t1);margin-bottom:8px">Saldo inicial: <span id="dca-base-display" style="color:var(--t0);font-weight:600"></span> <span style="color:var(--t2)">(cartera activa)</span></div>
         <div class="two-col">
@@ -475,6 +476,7 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
           <div class="fg"><label>Horizonte (años)</label><input type="number" id="dca-years" value="10" min="1" max="40"></div>
         </div>
         <button class="btn btn-p" onclick="calcProy()">Calcular</button>
+        <button class="btn" style="margin-top:8px;width:100%" onclick="saveProy()">Guardar proyección</button>
       </div>
       <div class="card" id="card-proy" style="display:none">
         <div class="metric-grid" id="proy-metrics"></div>
@@ -1132,7 +1134,7 @@ const plats=[
   {nombre:'Coinbase',url:'https://www.coinbase.com',cat:'Cripto',color:'#0052ff',icon:'CB'},
 ];
 const idxData={'FTSE All-World':{ytd:'+8,2%',y1:'+12,4%',pe:'18,4x',div:'1,8%',n:'3.700+',desc:'Renta variable global desarrollada + emergente'},'MSCI World':{ytd:'+8,7%',y1:'+13,1%',pe:'19,8x',div:'1,5%',n:'1.400+',desc:'Renta variable mercados desarrollados'},'S&P 500':{ytd:'+9,1%',y1:'+14,2%',pe:'21,2x',div:'1,3%',n:'500',desc:'500 mayores empresas de EE.UU.'}};
-let notas=['Tesis: largo plazo DCA sobre índices globales.'],nextId=31,privacyOn=false,opsFilter='todas',opsLimit='20',lastBackupDate=null,appMode=localStorage.getItem('appMode')||'basic';
+let notas=['Tesis: largo plazo DCA sobre índices globales.'],nextId=31,privacyOn=false,opsFilter='todas',opsLimit='20',lastBackupDate=null,appMode=localStorage.getItem('appMode')||'basic',proyecciones=[],proyId=1;
 const canales=[
   {id:'ch1',nombre:'Fondos Indexados',ini:'FI',color:'#4a7fa5',cat:'ETFs',desc:'Inversión pasiva en índices globales, ETFs y estrategias de largo plazo.',url:'#',fav:false,dest:true},
   {id:'ch2',nombre:'Value School',ini:'VS',color:'#4a8c6f',cat:'Value',desc:'Value investing, análisis fundamental y filosofía de inversión a largo plazo.',url:'#',fav:true,dest:false},
@@ -1235,7 +1237,7 @@ function goTo(sid,btn){if(appMode==='basic'&&ADVANCED_SCREENS.includes(sid)){sid
   else if(sid==='s-perfil')renderPerfil();
   else if(sid==='s-canales')renderCanales();
   else if(sid==='s-ayuda')renderAyuda();
-  else if(sid==='s-proyeccion'){const el=document.getElementById('dca-base-display');if(el)el.textContent=fe(cV(activeId)||0);}
+  else if(sid==='s-proyeccion'){const el=document.getElementById('dca-base-display');if(el)el.textContent=fe(cV(activeId)||0);renderProyList();}
 }
 function renderQN(cur){['resumen','cartera','efectivo','ops','proyeccion','indices','notif','plataformas','rentabilidad','grupos','rent-efectivo','anotaciones','canales'].forEach(k=>{const el=document.getElementById('qn-'+k);if(!el)return;el.innerHTML=Object.entries(SL).filter(([id])=>id!==cur&&id!=='s-global'&&id!=='s-settings'&&id!=='s-perfil'&&id!=='s-ayuda'&&id!=='s-anotaciones'&&(appMode==='advanced'||!ADVANCED_SCREENS.includes(id))).map(([id,l])=>`<button class="qbtn" onclick="goTo('${id}')">${l}</button>`).join('');});}
 function renderAyuda(){}
@@ -1449,6 +1451,43 @@ function calcProy(){
       rows.map(r=>`<tr><td>${new Date().getFullYear()+r.y}</td><td class="pos"><span class="amt">${fe(r.final)}</span></td></tr>`).join('')+
       '</tbody></table>';
   }
+}
+function renderProyList(){
+  const lista=proyecciones.filter(p=>p.cartera===activeId);
+  const el=document.getElementById('proy-list');
+  const tit=document.getElementById('proy-titulo');
+  const cart=carteras.find(c=>c.id===activeId);
+  if(tit)tit.textContent=lista.length?`Proyecciones — ${cart?.nombre||''}`: 'Proyección DCA';
+  if(!el)return;
+  el.style.display=lista.length?'block':'none';
+  el.innerHTML=lista.length?`<div class="card" style="padding:10px"><div class="card-title" style="margin-bottom:8px">Proyecciones guardadas</div>`+
+    lista.map(p=>`<div class="dr" style="gap:8px;padding:4px 0"><span class="tag" onclick="loadProy(${p.id})" style="cursor:pointer;flex:1">${p.nombre}</span><button class="btn-icon" onclick="deleteProy(${p.id})" style="color:var(--neg);font-size:14px">🗑</button></div>`).join('')+
+    `</div>`:'';
+}
+function saveProy(){
+  const nombre=prompt('Nombre de esta proyección:');
+  if(!nombre||!nombre.trim())return;
+  proyecciones.push({id:proyId++,cartera:activeId,nombre:nombre.trim(),
+    amt:parseFloat(document.getElementById('dca-amt').value)||300,
+    freq:document.getElementById('dca-freq').value,
+    rate:parseFloat(document.getElementById('dca-rate').value)||8,
+    years:parseInt(document.getElementById('dca-years').value)||10});
+  renderProyList();
+  showToast('Proyección guardada ✓');
+}
+function loadProy(id){
+  const p=proyecciones.find(x=>x.id===id);
+  if(!p)return;
+  document.getElementById('dca-amt').value=p.amt;
+  document.getElementById('dca-freq').value=p.freq;
+  document.getElementById('dca-rate').value=p.rate;
+  document.getElementById('dca-years').value=p.years;
+  calcProy();
+}
+function deleteProy(id){
+  if(!confirm('¿Eliminar esta proyección?'))return;
+  proyecciones=proyecciones.filter(x=>x.id!==id);
+  renderProyList();
 }
 function renderIndices(){const idx={};activos.forEach(a=>{if(a.indice&&a.indice!=='-'){if(!idx[a.indice])idx[a.indice]=[];idx[a.indice].push(a.ticker);}});if(!Object.keys(idx).length){document.getElementById('lista-indices').innerHTML='<div style="font-size:13px;color:var(--t1);padding:12px 0">Ningún activo de esta cartera sigue un índice.</div>';return;}document.getElementById('lista-indices').innerHTML=Object.entries(idx).map(([name,ticks])=>{const d=idxData[name]||{ytd:'—',y1:'—',pe:'—',div:'—',n:'—',desc:'Índice personalizado'};return`<div class="card"><div class="card-header"><span class="card-title">${name}</span><span class="badge b-blue">${ticks.join(', ')}</span></div><div class="dr"><span class="dk">YTD</span><span class="dv pos">${d.ytd}</span></div><div class="dr"><span class="dk">12 meses</span><span class="dv pos">${d.y1}</span></div><div class="dr"><span class="dk">PER</span><span class="dv">${d.pe}</span></div><div class="dr"><span class="dk">Dividendo</span><span class="dv">${d.div}</span></div><div class="dr"><span class="dk">N.º valores</span><span class="dv">${d.n}</span></div><div style="margin-top:7px;font-size:11px;color:var(--t1)">${d.desc}</div></div>`;}).join('');}
 function renderNotif(){document.getElementById('notif-dot').style.display='none';notifs.forEach(n=>n.leida=true);const ic={alerta:'⚠',dca:'📅',info:'✓'},co={alerta:'b-coral',dca:'b-blue',info:'b-teal'};document.getElementById('lista-notif').innerHTML=notifs.map(n=>`<div class="card" id="notif-${n.id}" style="opacity:${n.leida?.85:1}"><div style="display:flex;align-items:flex-start;gap:10px"><span class="badge ${co[n.tipo]}" style="margin-top:1px">${ic[n.tipo]}</span><div style="flex:1"><div style="font-size:13px;color:var(--t0);margin-bottom:3px">${n.texto}</div><div style="font-size:11px;color:var(--t1)">${n.fecha}</div></div><div style="display:flex;gap:4px;flex-shrink:0"><button onclick="toggleFavNotif(${n.id})" style="background:none;border:none;cursor:pointer;font-size:16px;padding:2px" title="Favorita">${n.favorita?'⭐':'☆'}</button><button onclick="borrarNotif(${n.id})" style="background:none;border:none;cursor:pointer;font-size:14px;color:var(--t2);padding:2px" title="Borrar">✕</button></div></div></div>`).join('')||'<div style="font-size:13px;color:var(--t1);padding:12px 0">Sin notificaciones.</div>';}


### PR DESCRIPTION
## Summary

Implementa el spec aprobado en `docs/superpowers/specs/2026-04-27-modo-basico-avanzado-proyecciones-design.md`.

**Modo básico/avanzado:**
- Switch gratuito en Ajustes → Modo de uso, persistido en localStorage
- Modo básico por defecto — oculta 6 pantallas avanzadas (Rentabilidad TWR, Grupos, Rent. Efectivo, Índices, Anotaciones, Canales)
- Guard en `goTo()` redirige a Global si se intenta navegar a pantalla avanzada en modo básico
- Quick nav filtra pantallas avanzadas en modo básico

**Proyecciones DCA guardadas:**
- Guardar escenarios con nombre por cartera activa
- Cargar proyección guardada → rellena formulario y recalcula
- Eliminar proyección con confirmación
- Título dinámico muestra la cartera activa

**ESTADO.md:**
- Nota en sec 2 sobre el modo básico/avanzado
- Texto de onboarding en sec 20 menciona los dos modos

🤖 Generated with [Claude Code](https://claude.com/claude-code)