### PR TITLE
docs: actualizar SPEC.md y BUSINESS_PLAN.md

### DIFF
--- a/docs/BUSINESS_PLAN.md
+++ b/docs/BUSINESS_PLAN.md
@@ -148,13 +148,13 @@ Asesores financieros independientes, family offices. Acceso de lectura a cartera
 
 ### Estado actual
 
-El **Prototipo v6** está completo y en pruebas con usuarios reales. Es un prototipo HTML autocontenido que valida flujos y experiencia de usuario, sin backend. Incluye 16 pantallas funcionales: global, resumen, cartera, efectivo, operaciones, rentabilidad TWR, proyección DCA, índices, guía de uso integrada y preguntas frecuentes.
+El **Prototipo v6** está completo y en pruebas con usuarios reales. Es un prototipo HTML autocontenido que valida flujos y experiencia de usuario, sin backend. Incluye 17 pantallas funcionales con modo básico/avanzado, proyecciones DCA guardadas, cancelación de operaciones y FAQ integrada.
 
 ### Roadmap
 
 | Fase | Entregable | Plazo estimado |
 |---|---|---|
-| **Prototipo 2** | Validación arquitectura local-first: React Native + Expo SQLite + PowerSync + Supabase | 3-4 meses |
+| **Prototipo 2** | Validación arquitectura local-first: React Native + WatermelonDB + Supabase (sin dependencia de terceros en capa sync) | 3-4 meses |
 | **Beta cerrada** | App iOS + Android con funcionalidades core, 100 usuarios beta | 6-8 meses |
 | **Lanzamiento v1** | App Store + Google Play + Web, Plan Personal disponible | 10-12 meses |
 | **v1.1** | Plan Profesional B2B, importación PDF de broker con IA | 14-16 meses |
@@ -181,7 +181,7 @@ El **Prototipo v6** está completo y en pruebas con usuarios reales. Es un proto
 - **Funcionamiento offline completo** — el usuario consulta y registra operaciones sin conexión. Relevante en mercados latinoamericanos con conectividad variable.
 - **Comunidad hispanohablante ya educada** — existe un ecosistema maduro de blogs, podcasts y canales de YouTube sobre inversión en español (El Inversor Inteligente, Indexa Capital, Finect…) que genera demanda orgánica y facilita la distribución.
 - **Coste de infraestructura mínimo** — la arquitectura local-first desplaza el coste computacional al dispositivo. El backend gestiona solo sync, auth y licencias.
-- **Prototipo validado con usuarios reales** — 16 pantallas funcionales en pruebas con inversores reales.
+- **Prototipo validado con usuarios reales** — 17 pantallas funcionales en pruebas con inversores reales.
 - **Modelo de monetización sin publicidad** — los datos financieros del usuario nunca se monetizan, lo que refuerza el argumento de privacidad.
 - **Escalabilidad geográfica natural** — España como mercado de validación, con expansión natural a México, Argentina, Colombia y Chile sin cambio de idioma ni de producto.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -80,9 +80,21 @@ Agrupaciones predefinidas y personalizables:
 - Actualización online en tiempo real (v2)
 
 ### 10. Anotaciones
-- Anotaciones a todos los niveles: activo, broker, grupo, cartera, global
+- Anotaciones globales del usuario (pantalla dedicada `s-anotaciones`)
+- Notas por activo individual (accesibles desde el detalle del activo)
 - No interfieren con el flujo ni la navegación
-- Accesibles desde el detalle de cada entidad
+
+### 13. Rentabilidad efectivo (`s-rent-efectivo`)
+- Rentabilidad calculada sobre los movimientos de efectivo
+
+### 14. Perfil (`s-perfil`)
+- Datos del usuario, gestión de cuenta
+
+### 15. Canales / Aprende (`s-canales`)
+- Canales de contenido curados para formación inversora
+
+### 16. Ayuda / FAQ (`s-ayuda`)
+- Preguntas frecuentes, guía de uso, información sobre el cálculo de precio medio
 
 ### 11. Detalle de activo
 Pantalla individual por activo con:
@@ -107,7 +119,7 @@ Pantalla individual por activo con:
 ---
 
 ## Navegación
-- Menú inferior estilo móvil (7 secciones principales)
+- Menú inferior estilo móvil (8 secciones principales)
 - Acceso rápido cross-screen desde cada pantalla
 - Selector de cartera siempre visible en la barra superior
 - Botón de acceso directo a vista global
@@ -144,7 +156,8 @@ Pantalla individual por activo con:
 
 | Versión | Contenido |
 |---------|-----------|
-| v0.1 | Prototipo UI completo (actual) |
+| v6 (HTML) | Prototipo UI completo — 17 pantallas, modo básico/avanzado, proyecciones DCA (actual) |
+| Prototipo 2 | Validación arquitectura local-first: React Native + WatermelonDB + Supabase |
 | v1.0 | App funcional con datos reales, sin APIs externas |
 | v1.5 | Integración cotizaciones en tiempo real |
-| v2.0 | Autenticación biométrica WebAuthn, app móvil nativa |
+| v2.0 | Autenticación biométrica WebAuthn, funcionalidades avanzadas |


### PR DESCRIPTION
## Summary

Corrige gaps detectados en el code review del 2026-04-27.

**SPEC.md:**
- Nav bar: 7 → 8 secciones
- Versiones: v0.1 → v6 (17 pantallas), añadido Prototipo 2 y roadmap actualizado
- Añadidas 4 pantallas que faltaban: s-rent-efectivo, s-perfil, s-canales, s-ayuda
- Anotaciones: corregido alcance (solo global + por activo, no broker/grupo/cartera)

**BUSINESS_PLAN.md:**
- Estado actual: 16 → 17 pantallas
- Prototipo 2: PowerSync → WatermelonDB (decisión arquitectónica 2026-04-27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)