### PR TITLE
docs: prohibir lectura completa de archivos grandes en CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ Al cambiar modo oscuro, llamar `reCharts()` para re-renderizar los activos.
 
 ## Lo que NO hacer
 
+- **NUNCA leer `prototype/index.html` ni `ESTADO.md` completos** — usar siempre Grep o Read con offset/limit. Son archivos grandes (index.html ~184KB, ESTADO.md ~43K tokens) que llenan el contexto en un solo turno y causan error irrecuperable de 1M_CONTEXT.
 - **No separar en múltiples archivos** — es un monolito por diseño (facilita compartir y desplegar en Netlify Drop)
 - **No añadir dependencias** salvo Chart.js (ya incluido por CDN)
 - **No usar `localStorage`** — los datos viven en memoria durante la sesión

--- a/ESTADO.md
+++ b/ESTADO.md
@@ -15,7 +15,7 @@
 | Divisas | Multi-divisa (EUR, USD y otras) | Tipos de cambio manuales en prototipo, automáticos en producción |
 | Offline / cloud | **Híbrido** — ver sección 20 | Datos operacionales local-first + sync; resto en Supabase |
 | Plataforma | **React Native + Expo + web** | iOS + Android + web — las tres plataformas desde una base de código |
-| Nombre comercial | Pendiente de decidir | Nombre interno: portapp |
+| Nombre comercial | **Portgrow** | Dominio: portgrow.app (registrado 2026-04-28) |
 | Repo | GitHub privado (whistle59/portapp) | Branches: `main` (estable) + `dev` (integración) + `feature/*` (trabajo) |
 | CI/CD | GitHub Actions | Validación HTML en cada push a `dev` y PR a `main` |
 


### PR DESCRIPTION
Añade regla explícita en 'Lo que NO hacer' para no leer `prototype/index.html` ni `ESTADO.md` completos, evitando el error irrecuperable de 1M_CONTEXT.