### PR TITLE
ci: sleep 30 antes de auto-merge en sync-dev para evitar unstable status

### DIFF
--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -71,4 +71,5 @@ jobs:
             --body "Automatic PR created after merging into main, to keep dev aligned with main.")
 
           PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
+          sleep 30
           gh pr merge "$PR_NUMBER" --auto --merge


### PR DESCRIPTION
El workflow fallaba con 'Pull request is in unstable status' porque intentaba activar auto-merge antes de que los checks de CI arrancaran. Con sleep 30 se da margen suficiente.