### PR TITLE
docs: DECISIONS.md (10 ADRs) y CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Portgrow — Guía de contribución
+
+---
+
+## Ramas y flujo de trabajo
+
+```
+main          ← rama estable, solo recibe merges desde dev
+dev           ← rama de integración
+feature/*     ← una rama por funcionalidad o fix
+```
+
+**Regla cardinal:** ningún commit va directamente a `main` ni a `dev`. Todo pasa por una rama `feature/*` y un PR.
+
+```
+feature/mi-cambio → PR a dev → (revisión) → merge → sync automático a main → merge a main
+```
+
+El workflow `.github/workflows/sync-dev.yml` abre y mergea automáticamente el PR `main → dev` cada vez que se mergea algo a `main`, para mantener ambas ramas alineadas.
+
+---
+
+## Crear una rama de trabajo
+
+```bash
+git checkout dev && git pull origin dev
+git checkout -b feature/descripcion-corta
+```
+
+Prefijos de nombre de rama:
+
+| Prefijo | Uso |
+|---|---|
+| `feature/` | Nueva funcionalidad |
+| `fix/` | Corrección de bug |
+| `docs/` | Solo documentación |
+| `refactor/` | Refactorización sin cambio de comportamiento |
+
+---
+
+## Commits
+
+Formato: `tipo: descripción en imperativo, en español`
+
+```
+feat: añadir modal de consentimiento de backup
+fix: separador de miles en pantalla Efectivo
+docs: sección 35 — estrategia de entornos
+refactor: extraer cartaHead() y cartaRows() de renderCartera
+```
+
+Tipos: `feat` · `fix` · `docs` · `refactor` · `test` · `chore`
+
+Una línea. Sin punto final. Sin "he añadido" ni "añadimos" — imperativo directo.
+
+---
+
+## Pull Requests
+
+- **Base siempre `dev`**, nunca `main`
+- Título = mensaje del commit principal
+- Descripción: qué cambia, pantallas afectadas, cómo probar
+- Antes de abrir el PR: comprobar que el prototipo abre sin errores en el navegador
+- Miguel revisa y mergea — no se hace auto-merge en feature → dev
+
+---
+
+## Trabajar con el prototipo (`prototype/index.html`)
+
+El prototipo es un único fichero HTML + CSS + JS. Antes de editar:
+
+```bash
+# Localizar la sección exacta, nunca leer el fichero entero
+grep -n "renderEfectivo\|función que busco" prototype/index.html
+```
+
+Convenciones del código (ver `CLAUDE.md` para el detalle completo):
+
+- JS vanilla, sin módulos, sin TypeScript
+- Template literals para HTML dinámico
+- Variables CSS (`var(--nombre)`) para todos los colores — nunca valores fijos
+- `fe(n)` para formatear importes monetarios (`€12.345`)
+- `fp(n)` para porcentajes (`+12,3%`)
+- Destruir el chart antes de re-renderizar: `if(chX) chX.destroy()`
+
+---
+
+## Archivos clave
+
+| Archivo | Contenido |
+|---|---|
+| `prototype/index.html` | Todo el prototipo (~184 KB) |
+| `ESTADO.md` | Estado actual, backlog, decisiones de producto |
+| `docs/DECISIONS.md` | ADR — decisiones de arquitectura |
+| `docs/SPEC.md` | Especificación técnica |
+| `docs/DATA_MODEL.md` | Modelo de datos v1.x |
+| `docs/BUSINESS_PLAN.md` | Plan de negocio |
+| `CLAUDE.md` | Instrucciones para el agente de IA |
+
+> **ESTADO.md** e `index.html` son ficheros grandes. Usar siempre `grep` o `Read` con `offset/limit` — nunca leerlos completos.
+
+---
+
+## Entornos y base de datos
+
+Ver `docs/DECISIONS.md` ADR-009 y `ESTADO.md` sección 35 para la estrategia completa.
+
+En resumen:
+- `portgrow-dev` — desarrollo y pruebas
+- `portgrow-prod` — usuarios reales
+- Los cambios de schema van en `supabase/migrations/` y se aplican vía CI/CD, nunca manualmente
+
+---
+
+## Lo que NO hacer
+
+- No mergear directamente a `main`
+- No leer `index.html` ni `ESTADO.md` completos (error de contexto irrecuperable)
+- No añadir dependencias npm al prototipo (solo Chart.js vía CDN)
+- No usar `localStorage` en el prototipo (los datos viven en memoria)
+- No tocar el bloque de autenticación sin leer ese bloque completo primero
+- No cambiar el modelo de IA (Haiku/Opus/Sonnet) sin autorización explícita de Miguel

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,161 @@
+# Portgrow — Decision Log (ADR)
+
+Registro de decisiones de arquitectura y producto. Cada entrada explica **qué** se decidió, **por qué** y **qué alternativas se descartaron**. Las decisiones son inmutables: si una decisión cambia, se añade una nueva entrada que la supersede.
+
+---
+
+## ADR-001 · Prototipo como fichero HTML único
+
+**Fecha:** 2026-04 (inicio del proyecto)
+**Estado:** Vigente
+
+**Decisión:** Todo el prototipo vive en un único fichero autocontenido (`prototype/index.html`) sin build, sin dependencias npm y sin servidor.
+
+**Por qué:** Máxima portabilidad para compartir con testers (abrir en navegador sin instalar nada). Netlify Drop permite despliegue en segundos. Facilita iterar sobre diseño y flujos sin fricción de entorno.
+
+**Alternativas descartadas:**
+- React/Vite: overhead de entorno innecesario en fase de prototipo
+- Varios ficheros HTML: complica el despliegue one-file
+
+**Consecuencias:** El fichero crece (~184 KB). No se separa en módulos hasta la fase de desarrollo real en React Native.
+
+---
+
+## ADR-002 · Arquitectura híbrida local-first + servidor
+
+**Fecha:** 2026-04-24
+**Estado:** Vigente
+
+**Decisión:** Los datos del usuario (carteras, operaciones, efectivo) viven localmente en el dispositivo (SQLite vía WatermelonDB). El servidor gestiona cotizaciones, auth, pagos y analytics.
+
+**Por qué:** La app debe funcionar sin conexión. Los datos financieros son sensibles — el usuario no quiere depender de que nuestro servidor esté operativo para ver su cartera. La latencia percibida es cero para lecturas.
+
+**Alternativas descartadas:**
+- Todo en servidor (API-first): requiere conexión constante, mayor latencia, mayor coste de infraestructura
+- Todo local (sin servidor): imposible ofrecer cotizaciones en tiempo real, sync multi-dispositivo ni auth centralizada
+
+---
+
+## ADR-003 · React Native + Expo como plataforma de producción
+
+**Fecha:** 2026-04-24
+**Estado:** Vigente
+
+**Decisión:** La app de producción se desarrollará con React Native + Expo, apuntando a iOS, Android y Web desde una única base de código.
+
+**Por qué:** El público objetivo usa mayoritariamente móvil. Expo reduce la fricción de build y OTA updates. Una sola base de código evita duplicar lógica de negocio.
+
+**Alternativas descartadas:**
+- Flutter: ecosistema JS/TS más familiar, mejor integración con Supabase SDK
+- Capacitor/Ionic: rendimiento inferior en listas largas (cartera con muchos activos)
+- Apps nativas separadas (Swift + Kotlin): coste de desarrollo x2, inviable para un equipo pequeño
+
+---
+
+## ADR-004 · Supabase como backend
+
+**Fecha:** 2026-04-24
+**Estado:** Vigente
+
+**Decisión:** Supabase (PostgreSQL + Auth + Edge Functions + RLS + Storage) como backend principal.
+
+**Por qué:** Ofrece auth, base de datos relacional, RLS por fila y Edge Functions en un solo servicio gestionado. El tier gratuito permite arrancar sin coste. SDK oficial para React Native.
+
+**Alternativas descartadas:**
+- Firebase: modelo de datos NoSQL menos adecuado para datos financieros relacionales; vendor lock-in más agresivo
+- Backend propio (Node + Postgres): tiempo de desarrollo y mantenimiento mucho mayor para un equipo pequeño
+- PlanetScale: no incluye auth ni storage nativos
+
+---
+
+## ADR-005 · WatermelonDB para sincronización local-servidor
+
+**Fecha:** 2026-04-27
+**Estado:** Vigente — supersede evaluación previa de PowerSync y Electric SQL
+
+**Decisión:** WatermelonDB (MIT) como capa de persistencia local y sincronización con Supabase.
+
+**Por qué:** Licencia MIT sin dependencia de terceros para el sync. Rendimiento probado en apps con miles de registros. API bien documentada para React Native. El protocolo de sync es implementable sobre cualquier backend REST/GraphQL, incluyendo Supabase Edge Functions.
+
+**Alternativas descartadas:**
+- PowerSync: servicio de pago con dependencia del proveedor para la capa de sync
+- Electric SQL: en fase alpha en el momento de la evaluación, riesgo de cambios de API
+- SQLite + sync manual: viable pero requiere implementar resolución de conflictos desde cero
+
+---
+
+## ADR-006 · Paddle como Merchant of Record
+
+**Fecha:** 2026-04-24
+**Estado:** Vigente
+
+**Decisión:** Paddle gestiona pagos, facturación, IVA internacional y cumplimiento fiscal como Merchant of Record.
+
+**Por qué:** Portgrow vende a usuarios de múltiples países. Gestionar IVA europeo, impuestos de ventas de EE.UU. y otros localmente es inviable para un equipo pequeño. Paddle asume esa responsabilidad legal.
+
+**Alternativas descartadas:**
+- Stripe: requiere gestionar el cumplimiento fiscal por países manualmente (complejidad y riesgo legal)
+- RevenueCat: especializado en in-app purchases de App Store/Play Store, no en web
+
+---
+
+## ADR-007 · Modelo de datos: Kimball (analytics) + 3NF (operacional)
+
+**Fecha:** 2026-04-24
+**Estado:** Vigente
+
+**Decisión:** Base de datos operacional en tercera forma normal (3NF) en el schema `public` de Supabase. DWH analítico en schema `analytics` con modelo dimensional Kimball (tablas de hechos + dimensiones).
+
+**Por qué:** 3NF garantiza integridad referencial y facilita las operaciones CRUD del día a día. Kimball permite queries analíticas eficientes (rentabilidad histórica, distribución por grupos, evolución de cartera) sin afectar al rendimiento operacional.
+
+**Alternativas descartadas:**
+- Todo en 3NF: queries analíticas complejas y lentas a medida que crecen los datos
+- Todo en modelo dimensional: actualizaciones e inserciones operacionales incómodas
+
+---
+
+## ADR-008 · Nombre comercial: Portgrow / portgrow.app
+
+**Fecha:** 2026-04-28
+**Estado:** Vigente
+
+**Decisión:** El nombre comercial del producto es **Portgrow**. Dominio registrado: `portgrow.app` en IONOS.
+
+**Por qué:** Combina "portfolio" y "grow" de forma clara para el público hispanohablante e internacional. `portgrow.app` disponible y sin conflictos de marca evidentes en los registros consultados. `portgrow.com` era un dominio premium (€2.500).
+
+**Alternativas descartadas:**
+- Portrak: empresa existente de seguimiento de mercados en portrak.com (conflicto de marca)
+- Fintrack: dominio .com no disponible
+- Cartrack: connotaciones de rastreo de automóviles ("car")
+- Portrack / Porttrack: variantes evaluadas, Portgrow resultó más evocador del crecimiento
+
+**Pendiente:** Búsqueda y registro de marca en EUIPO — clases 9, 36 y 42 (ver ESTADO.md sec. 32).
+
+---
+
+## ADR-009 · Dos entornos Supabase: dev y prod
+
+**Fecha:** 2026-04-30
+**Estado:** Vigente
+
+**Decisión:** Dos proyectos Supabase independientes: `portgrow-dev` y `portgrow-prod`. Los cambios de schema solo llegan a prod mediante migraciones versionadas con Supabase CLI, nunca manualmente.
+
+**Por qué:** Protege los datos reales de usuarios de experimentos y migraciones erróneas. Obliga a formalizar todos los cambios de schema desde el primer día, evitando la deuda técnica de "ya lo igualaré después".
+
+**Alternativas descartadas:**
+- Un solo proyecto con schemas separados (dev/prod): un error de migración puede afectar a datos reales
+- Entorno dev local únicamente: no detecta problemas de permisos RLS ni de configuración Supabase real
+
+---
+
+## ADR-010 · Tabla central `user_consents` para todos los consentimientos
+
+**Fecha:** 2026-04-30
+**Estado:** Vigente
+
+**Decisión:** Todos los consentimientos del usuario (GDPR, términos, backup, marketing) se almacenan en una única tabla `user_consents` con `consent_type`, `version`, timestamps de aceptación/revocación y trazabilidad de IP/user-agent.
+
+**Por qué:** Punto único de auditoría para cumplimiento GDPR. Facilita gestionar versiones de políticas (al actualizar los términos, basta con comprobar si el usuario aceptó la versión actual). Evita campos dispersos en la tabla de usuarios que se vuelven difíciles de mantener.
+
+**Alternativas descartadas:**
+- Campos booleanos en la tabla `users` (`gdpr_accepted`, `backup_consent`…): no guarda historial ni versiones; incumple requisitos de trazabilidad GDPR


### PR DESCRIPTION
## Cambios

Dos ficheros nuevos en `docs/`:

### `DECISIONS.md` — 10 ADRs
Registro inmutable de decisiones de arquitectura y producto:
- ADR-001: Prototipo HTML único
- ADR-002: Arquitectura híbrida local-first
- ADR-003: React Native + Expo
- ADR-004: Supabase como backend
- ADR-005: WatermelonDB para sync
- ADR-006: Paddle como Merchant of Record
- ADR-007: Kimball (analytics) + 3NF (operacional)
- ADR-008: Nombre comercial Portgrow / portgrow.app
- ADR-009: Dos entornos Supabase (dev + prod)
- ADR-010: Tabla central `user_consents`

### `CONTRIBUTING.md`
- Flujo de ramas y PRs
- Convenciones de commits
- Guía para trabajar con el prototipo
- Archivos clave del repositorio
- Lo que NO hacer

🤖 Generated with [Claude Code](https://claude.com/claude-code)