### PR TITLE
fix: renombrar pantalla Ajustes → Config/Configuración

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -534,7 +534,7 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
 
     <!-- SETTINGS -->
     <div class="screen" id="s-settings">
-      <div class="screen-title">Ajustes</div>
+      <div class="screen-title">Configuración</div>
       <div class="slabel" style="margin-bottom:7px">Modo de uso</div>
       <div class="card">
         <div class="dr">
@@ -590,7 +590,7 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
 
     <!-- AYUDA (H1+H3) -->
     <div class="screen" id="s-ayuda">
-      <div class="breadcrumb"><button class="bc-link" onclick="goTo('s-settings')">← Ajustes</button></div>
+      <div class="breadcrumb"><button class="bc-link" onclick="goTo('s-settings')">← Config</button></div>
       <div class="screen-title">Guía de uso</div>
 
       <div class="slabel" style="margin-bottom:8px">Pantallas</div>
@@ -624,14 +624,14 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
       <details><summary>¿Cómo creo una cartera nueva?</summary><div class="det-body">Toca el nombre de la cartera en la barra superior y pulsa <strong>"+ Nueva cartera"</strong> en la parte inferior del selector.</div></details>
       <details><summary>¿Qué es el método RPT?</summary><div class="det-body">RPT (Rentabilidad Ponderada por Tiempo) es la forma estándar de medir la rentabilidad real de una cartera. Elimina el efecto de cuándo hiciste cada aportación o retirada, por lo que refleja únicamente el rendimiento de las inversiones. Es el método que usan los fondos de inversión para publicar su rentabilidad.</div></details>
       <details><summary>¿Cómo oculto las cifras si alguien ve mi pantalla?</summary><div class="det-body">Pulsa el icono <strong>👁</strong> de la barra superior. Todas las cifras de la app se enmascaran con ••••. Tócalo de nuevo para desactivarlo, o pulsa la barra que aparece en la parte superior de la pantalla.</div></details>
-      <details><summary>¿Cómo activo el modo oscuro?</summary><div class="det-body">Ve a <strong>Ajustes &gt; Interfaz</strong> y activa el interruptor de modo oscuro.</div></details>
+      <details><summary>¿Cómo activo el modo oscuro?</summary><div class="det-body">Ve a <strong>Config &gt; Interfaz</strong> y activa el interruptor de modo oscuro.</div></details>
       <details><summary>¿Mis datos se envían a algún servidor?</summary><div class="det-body">No. El prototipo funciona completamente en tu navegador, sin enviar ningún dato a servidores externos. En la versión de producción, los datos se guardarán en tu dispositivo y solo se sincronizarán con la nube si tú lo activas expresamente.</div></details>
       <details><summary>¿Qué pasa si cierro el navegador?</summary><div class="det-body">En el prototipo actual los datos de la sesión no se guardan — al cerrar y volver a abrir la app, los datos vuelven al estado inicial de demo. En la versión de producción los datos quedarán guardados permanentemente en tu dispositivo.</div></details>
 
       <div class="slabel" style="margin-top:18px;margin-bottom:8px">Copia de seguridad</div>
 
       <details><summary>Cómo hacer un backup</summary><div class="det-body">
-        <div class="help-step"><div class="help-step-num">1</div><div>Ve a <strong>Ajustes &gt; Datos</strong> y pulsa <strong>"📤 Exportar · Importar · Backup"</strong>.</div></div>
+        <div class="help-step"><div class="help-step-num">1</div><div>Ve a <strong>Config &gt; Datos</strong> y pulsa <strong>"📤 Exportar · Importar · Backup"</strong>.</div></div>
         <div class="help-step"><div class="help-step-num">2</div><div>En el panel que se abre, baja hasta la sección <strong>Copia de seguridad</strong>.</div></div>
         <div class="help-step"><div class="help-step-num">3</div><div>Pulsa <strong>"💾 Hacer backup"</strong>. Se descargará un archivo con todos tus datos.</div></div>
         <div class="help-step"><div class="help-step-num">4</div><div>Guarda ese archivo en un lugar seguro: iCloud, Google Drive, una carpeta de tu ordenador, etc.</div></div>
@@ -640,7 +640,7 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
 
       <details><summary>Cómo restaurar un backup</summary><div class="det-body">
         <div style="background:var(--neg-bg,#fff0f0);border-left:3px solid var(--neg);padding:9px 12px;border-radius:6px;font-size:12px;color:var(--t1);margin-bottom:12px;line-height:1.55">⚠️ <strong>Atención:</strong> restaurar un backup reemplaza todos los datos actuales de la app por los del backup. Las operaciones registradas después de esa fecha se perderán.</div>
-        <div class="help-step"><div class="help-step-num">1</div><div>Ve a <strong>Ajustes &gt; Datos</strong> y pulsa <strong>"📤 Exportar · Importar · Backup"</strong>.</div></div>
+        <div class="help-step"><div class="help-step-num">1</div><div>Ve a <strong>Config &gt; Datos</strong> y pulsa <strong>"📤 Exportar · Importar · Backup"</strong>.</div></div>
         <div class="help-step"><div class="help-step-num">2</div><div>Pulsa <strong>"📥 Restaurar backup"</strong> y selecciona el archivo de backup que quieres usar.</div></div>
         <div class="help-step"><div class="help-step-num">3</div><div>La app te mostrará la fecha del backup y te pedirá confirmación. Lee el aviso con calma antes de continuar.</div></div>
         <div class="help-step"><div class="help-step-num">4</div><div>Antes de restaurar, la app guarda automáticamente una copia de tu estado actual, por si necesitas recuperarlo.</div></div>
@@ -699,7 +699,7 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
     <!-- PERFIL (F4) -->
     <div class="screen" id="s-perfil">
       <div class="breadcrumb">
-        <button class="bc-link" onclick="goTo('s-settings')">← Ajustes</button>
+        <button class="bc-link" onclick="goTo('s-settings')">← Config</button>
       </div>
       <div class="screen-title">Perfil</div>
       <div style="display:flex;align-items:center;gap:14px;margin-bottom:18px">
@@ -808,7 +808,7 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
     <button class="nav-item" id="nav-ops" onclick="goTo('s-ops',this)"><svg class="ni-svg" width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M3 5h12M3 9h8M3 13h10" stroke-width="1.3" stroke-linecap="round"/></svg><span class="nav-label">Ops.</span></button>
     <button class="nav-item" id="nav-proyeccion" onclick="goTo('s-proyeccion',this)"><svg class="ni-svg" width="18" height="18" viewBox="0 0 18 18" fill="none"><polyline points="1,14 6,8 10,11 17,3" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="nav-label">DCA</span></button>
     <button class="nav-item nav-advanced" id="nav-indices" onclick="goTo('s-indices',this)"><svg class="ni-svg" width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="9" r="7" stroke-width="1.3"/><line x1="9" y1="2" x2="9" y2="16" stroke-width="1.3"/><line x1="2" y1="9" x2="16" y2="9" stroke-width="1.3"/></svg><span class="nav-label">Mercado</span></button>
-    <button class="nav-item" id="nav-settings" onclick="goTo('s-settings',this)"><svg class="ni-svg" width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="9" r="2.5" stroke-width="1.3"/><path d="M9 1v2M9 15v2M1 9h2M15 9h2M3.2 3.2l1.4 1.4M13.4 13.4l1.4 1.4M3.2 14.8l1.4-1.4M13.4 4.6l1.4-1.4" stroke-width="1.3" stroke-linecap="round"/></svg><span class="nav-label">Ajustes</span></button>
+    <button class="nav-item" id="nav-settings" onclick="goTo('s-settings',this)"><svg class="ni-svg" width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="9" r="2.5" stroke-width="1.3"/><path d="M9 1v2M9 15v2M1 9h2M15 9h2M3.2 3.2l1.4 1.4M13.4 13.4l1.4 1.4M3.2 14.8l1.4-1.4M13.4 4.6l1.4-1.4" stroke-width="1.3" stroke-linecap="round"/></svg><span class="nav-label">Config</span></button>
   </div>
 </div>
 
@@ -1275,7 +1275,7 @@ function togglePwd(id,btn){const el=document.getElementById(id);el.type=el.type=
 function reCharts(){const a=id=>document.getElementById(id).classList.contains('active');if(a('s-global'))requestAnimationFrame(()=>requestAnimationFrame(renderGlobal));if(a('s-resumen'))requestAnimationFrame(()=>requestAnimationFrame(()=>{renderCR();renderHistorial('1S');}));if(a('s-rentabilidad'))requestAnimationFrame(()=>requestAnimationFrame(renderRentabilidad));if(a('s-grupos'))requestAnimationFrame(()=>requestAnimationFrame(renderGruposCapital));}
 const ADVANCED_SCREENS=['s-rentabilidad','s-grupos','s-rent-efectivo','s-indices','s-anotaciones'];
 const SCREENS=['s-global','s-resumen','s-cartera','s-efectivo','s-ops','s-proyeccion','s-indices','s-notif','s-plataformas','s-settings','s-rentabilidad','s-grupos','s-perfil','s-rent-efectivo','s-anotaciones','s-canales','s-ayuda'];
-const SL={'s-global':'Global','s-resumen':'Resumen','s-cartera':'Cartera','s-efectivo':'Efectivo','s-ops':'Ops.','s-proyeccion':'Proy.','s-indices':'Índices','s-notif':'Avisos','s-plataformas':'Links','s-settings':'Ajustes','s-rentabilidad':'Rentab.','s-grupos':'Grupos','s-perfil':'Perfil','s-rent-efectivo':'Rent.Ef.','s-anotaciones':'Notas','s-canales':'Aprende','s-ayuda':'Ayuda'};
+const SL={'s-global':'Global','s-resumen':'Resumen','s-cartera':'Cartera','s-efectivo':'Efectivo','s-ops':'Ops.','s-proyeccion':'Proy.','s-indices':'Índices','s-notif':'Avisos','s-plataformas':'Links','s-settings':'Config','s-rentabilidad':'Rentab.','s-grupos':'Grupos','s-perfil':'Perfil','s-rent-efectivo':'Rent.Ef.','s-anotaciones':'Notas','s-canales':'Aprende','s-ayuda':'Ayuda'};
 const NM={'s-global':'nav-global','s-resumen':'nav-resumen','s-cartera':'nav-cartera','s-efectivo':'nav-efectivo','s-ops':'nav-ops','s-proyeccion':'nav-proyeccion','s-indices':'nav-indices','s-settings':'nav-settings'};
 function goTo(sid,btn){if(appMode==='basic'&&ADVANCED_SCREENS.includes(sid)){sid='s-global';btn=null;}SCREENS.forEach(s=>document.getElementById(s).classList.remove('active'));document.getElementById(sid).classList.add('active');document.querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active'));const nb=btn||document.getElementById(NM[sid]);if(nb)nb.classList.add('active');closeAllModals();renderQN(sid);const sw=document.getElementById('sw');if(sw)sw.scrollTop=0;const ps=document.getElementById('port-sel');const gt=document.getElementById('global-title');if(ps)ps.style.display=sid==='s-global'?'none':'flex';if(gt)gt.style.display=sid==='s-global'?'block':'none';
   if(sid==='s-global'){requestAnimationFrame(()=>requestAnimationFrame(renderGlobal));}


### PR DESCRIPTION
## Cambios

Elimina la ambigüedad entre la pantalla de configuración y los ajustes de reconciliación (F16).

| Elemento | Antes | Después |
|---|---|---|
| Título de pantalla (`s-settings`) | Ajustes | Configuración |
| Nav bar inferior | Ajustes | Config |
| Objeto `SL` | `'s-settings':'Ajustes'` | `'s-settings':'Config'` |
| Breadcrumbs | ← Ajustes | ← Config |
| Textos FAQ | Ajustes > Interfaz / Datos | Config > Interfaz / Datos |

Los chips y badges de reconciliación ("Ajustes", "Ajuste") no se tocan — ese uso es correcto y ya no hay conflicto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)