### PR TITLE
chore: build automático — obfuscación + deploy a Netlify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Build & Deploy a Netlify
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'prototype/index.html'
+      - 'scripts/build.js'
+      - 'package.json'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Instalar dependencias
+        run: npm ci
+
+      - name: Obfuscar y generar dist/
+        run: npm run build
+
+      - name: Deploy a Netlify
+        uses: nwtgck/actions-netlify@v3
+        with:
+          publish-dir: './dist'
+          production-branch: main
+          production-deploy: true
+          deploy-message: "Deploy ${{ github.sha }}"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "portgrow-build",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "node scripts/build.js"
+  },
+  "devDependencies": {
+    "javascript-obfuscator": "^4.1.1"
+  }
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Obfusca prototype/index.html → dist/index.html
+// Uso: node scripts/build.js
+
+const fs = require('fs');
+const path = require('path');
+const { obfuscate } = require('javascript-obfuscator');
+
+const src = path.join(__dirname, '..', 'prototype', 'index.html');
+const outDir = path.join(__dirname, '..', 'dist');
+const out = path.join(outDir, 'index.html');
+
+if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
+
+const html = fs.readFileSync(src, 'utf8');
+
+// Extrae el bloque <script> final (el de la app, no CDNs)
+const scriptRe = /<script(?![^>]*src[^>]*)>([\s\S]*?)<\/script>\s*<\/body>/;
+const match = html.match(scriptRe);
+if (!match) { console.error('No se encontró el bloque <script> de la app'); process.exit(1); }
+
+const originalJs = match[1];
+const result = obfuscate(originalJs, {
+  compact: true,
+  controlFlowFlattening: false,
+  deadCodeInjection: false,
+  debugProtection: false,
+  disableConsoleOutput: false,
+  identifierNamesGenerator: 'hexadecimal',
+  renameGlobals: false,
+  selfDefending: false,
+  stringArray: true,
+  stringArrayEncoding: ['base64'],
+  stringArrayThreshold: 0.75,
+  transformObjectKeys: false,
+  unicodeEscapeSequence: false,
+});
+
+const obfuscatedHtml = html.replace(scriptRe, `<script>${result.getObfuscatedCode()}</script></body>`);
+fs.writeFileSync(out, obfuscatedHtml, 'utf8');
+console.log(`✓ dist/index.html generado (${Math.round(fs.statSync(out).size / 1024)} KB)`);


### PR DESCRIPTION
## Qué añade

Pipeline automático que se dispara en cada push a `main` cuando cambia `prototype/index.html`:

1. **`scripts/build.js`** — extrae el bloque `<script>` de la app (no los CDNs), lo obfusca con `javascript-obfuscator` (string array + base64, identificadores hexadecimales) y genera `dist/index.html`
2. **`package.json`** — dependencia `javascript-obfuscator`, script `npm run build`
3. **`.github/workflows/deploy.yml`** — Action que instala deps, ejecuta el build y despliega `dist/` a `portgrow.netlify.app` en producción

## Resultado

Cada vez que mergeas un PR a main, en ~2 minutos `portgrow.netlify.app` tiene la versión actualizada con el código obfuscado. Los testers usan siempre la misma URL.

## Primer deploy manual (una sola vez)

Después de mergear este PR, el workflow se dispara automáticamente. Si quieres probarlo antes localmente:
```bash
npm install
npm run build
# abre dist/index.html en el navegador para verificar
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)