### PR TITLE
fix: deploy workflow — Node 22 y npm install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,11 +16,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: '22'
 
       - name: Instalar dependencias
-        run: npm ci
+        run: npm install
 
       - name: Obfuscar y generar dist/
         run: npm run build


### PR DESCRIPTION
Corrige el fallo del workflow en PR #259:

- `node-version: 20` → `22` (Node 20 deprecado en GitHub Actions)
- `cache: 'npm'` eliminado + `npm ci` → `npm install` (npm ci requiere package-lock.json que no existe en el repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)