### PR TITLE
fix: desactivar auto-deploy Netlify + workflow_dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
       - 'prototype/index.html'
       - 'scripts/build.js'
       - 'package.json'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  ignore = "exit 0"


### PR DESCRIPTION
- `netlify.toml`: le dice a Netlify que ignore sus propios builds (`exit 0`) — el deploy lo gestiona exclusivamente GitHub Actions con el código obfuscado
- `deploy.yml`: añade `workflow_dispatch` para poder disparar el deploy manualmente desde GitHub Actions, y añade `.github/workflows/deploy.yml` a los paths vigilados

🤖 Generated with [Claude Code](https://claude.com/claude-code)