### PR TITLE
fix: responsive layout for Android landscape and iPad

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -23,6 +23,8 @@ html.dark{--bg0:#1c1c1e;--bg1:#2c2c2e;--bg2:#3a3a3c;--t0:#f5f5f7;--t1:#e8e8ec;--
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:var(--fs);color:var(--t0);background:var(--bg2);display:flex;justify-content:center;min-height:100vh;overscroll-behavior:none}
 .device{width:100%;max-width:390px;height:100vh;height:100dvh;background:var(--bg0);display:flex;flex-direction:column;position:relative;overflow:hidden}
 @media(min-width:500px){body{align-items:flex-start;padding:24px 0}.device{min-height:auto;height:min(800px,100dvh);border-radius:40px;box-shadow:0 24px 80px rgba(0,0,0,.22)}}
+@media(min-width:768px){.device{max-width:520px}}
+@media(orientation:landscape) and (max-height:500px){body{padding:0}.device{border-radius:0;box-shadow:none;height:100dvh;max-width:100%}}
 .masked .amt{position:relative;color:transparent!important}.masked .amt::after{content:'•••••';position:absolute;left:0;color:var(--t1);font-size:.9em}
 .privacy-bar{display:none;align-items:center;justify-content:center;gap:6px;background:var(--ac-bg);padding:6px 14px;font-size:12px;color:var(--ac-t);cursor:pointer;border-bottom:.5px solid var(--bd)}
 .privacy-bar.on{display:flex}


### PR DESCRIPTION
## Summary
- **Android landscape**: phones with viewport height ≤500px (landscape orientation) now get full-screen mode — body padding removed, device border-radius/shadow removed, `height:100dvh`. Prevents the floating-phone-in-padding layout that was breaking on Android.
- **iPad / tablet**: viewports ≥768px wide now show a 520px device instead of 390px, filling more of the screen without redesigning the UI.

## How it works
CSS cascade order ensures correct override priority:
1. Base: `max-width:390px`, full height (phones portrait)
2. `min-width:500px`: desktop preview mode (padding, border-radius, capped height)
3. `min-width:768px`: wider device for tablets
4. `orientation:landscape and max-height:500px`: last, wins — resets everything for phone landscape

## Test plan
- [ ] Android phone portrait → full-screen as before
- [ ] Android phone landscape → full-screen, no floating bubble
- [ ] iPad Chrome → device noticeably wider (520px)
- [ ] Desktop browser → unchanged preview bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)