### PR TITLE
docs: B11 layout tablet producción + aviso PR a main en CONTRIBUTING

### DIFF
--- a/ESTADO.md
+++ b/ESTADO.md
@@ -217,6 +217,7 @@
 | B8 | Calculadora de rebalanceo — cuánto comprar/vender para volver a la asignación objetivo (depende de B4) | Media |
 | B9 | Watchlist / lista de seguimiento de activos no comprados | Baja |
 | B10 | Vista de comisiones pagadas — total de fees por broker y por período | Baja |
+| B11 | Layout tablet para producción — la versión web responsive de producción debe tener un layout adaptado a tablet (≥768px): sidebar fijo, dos columnas o navegación lateral. El parche actual (max-width:520px en el prototipo) es temporal; en producción el diseño tablet debe ser nativo, no un teléfono ampliado. Ver sección 38 de ESTADO.md (diseño responsive) y M5 del roadmap. | Media |
 
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,6 +2,13 @@
 
 ---
 
+> **STOP — antes de abrir cualquier PR:**
+> `gh pr create` SIEMPRE con `--base dev`. Nunca `--base main`.
+> Si el PR ya existe contra `main`, cerrarlo y recrearlo contra `dev`.
+> Esta regla se ha violado en los PRs #149 y #267 — ambas veces con impacto en el historial de ramas.
+
+---
+
 ## Ramas y flujo de trabajo
 
 ```


### PR DESCRIPTION
## Cambios

**ESTADO.md — backlog B11:**
El `max-width:520px` añadido en PR #267 es un parche para el prototipo. En producción, el layout tablet debe ser nativo: sidebar fijo, dos columnas o navegación lateral para viewports ≥768px. Queda registrado como B11 (prioridad Media) para no olvidarlo.

**CONTRIBUTING.md — aviso al inicio:**
Se añade un bloque `> STOP` visible al principio del fichero recordando que `gh pr create` siempre lleva `--base dev`. Motivación: la regla ya existía (línea 60 y sección "Lo que NO hacer") pero no impidió que los PRs #149 y #267 fueran a main directamente.

## Test plan
- [ ] Solo cambios de documentación — sin impacto en el prototipo

🤖 Generated with [Claude Code](https://claude.com/claude-code)