### PR TITLE
fix: 6 bugs de testers ronda 2 + PWA manifest

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -8,6 +8,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="Portgrow">
+<link rel="manifest" href="manifest.json">
 <title>portapp — prototipo v6</title>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js"></script>
 <style>
@@ -20,6 +24,7 @@ html.dark{--bg0:#1c1c1e;--bg1:#2c2c2e;--bg2:#3a3a3c;--t0:#f5f5f7;--t1:#e8e8ec;--
 ::-webkit-scrollbar-track{background:transparent}
 ::-webkit-scrollbar-thumb{background:var(--ac);border-radius:4px}
 *{scrollbar-color:var(--ac) transparent;scrollbar-width:thin}
+summary{text-align:left}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:var(--fs);color:var(--t0);background:var(--bg2);display:flex;justify-content:center;min-height:100vh;overscroll-behavior:none}
 .device{width:100%;max-width:390px;height:100vh;height:100dvh;background:var(--bg0);display:flex;flex-direction:column;position:relative;overflow:hidden}
 @media(min-width:500px){body{align-items:flex-start;padding:24px 0}.device{min-height:auto;height:min(800px,100dvh);border-radius:40px;box-shadow:0 24px 80px rgba(0,0,0,.22)}}
@@ -239,12 +244,12 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
     <div id="oerr" class="err-box"></div>
     <div id="ook" class="ok-box">Correcto. Accediendo...</div>
     <div class="otp-row">
-      <input class="otp-in" type="text" maxlength="1" id="o0" oninput="otpMove(0)">
-      <input class="otp-in" type="text" maxlength="1" id="o1" oninput="otpMove(1)">
-      <input class="otp-in" type="text" maxlength="1" id="o2" oninput="otpMove(2)">
-      <input class="otp-in" type="text" maxlength="1" id="o3" oninput="otpMove(3)">
-      <input class="otp-in" type="text" maxlength="1" id="o4" oninput="otpMove(4)">
-      <input class="otp-in" type="text" maxlength="1" id="o5" oninput="otpMove(5)">
+      <input class="otp-in" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="1" id="o0" oninput="otpMove(0)">
+      <input class="otp-in" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="1" id="o1" oninput="otpMove(1)">
+      <input class="otp-in" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="1" id="o2" oninput="otpMove(2)">
+      <input class="otp-in" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="1" id="o3" oninput="otpMove(3)">
+      <input class="otp-in" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="1" id="o4" oninput="otpMove(4)">
+      <input class="otp-in" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="1" id="o5" oninput="otpMove(5)">
     </div>
     <div style="font-size:12px;color:var(--t1);text-align:center;margin-bottom:14px">Expira en <span id="tval" style="color:var(--ac);font-weight:600">9:47</span></div>
     <button class="btn btn-p" onclick="verifyOtp()">Verificar</button>
@@ -1284,6 +1289,8 @@ document.addEventListener('visibilitychange',()=>{
   function doLock(){
     document.getElementById('app-shell').classList.remove('active');
     document.getElementById('auth-wrap').style.display='flex';
+    document.querySelectorAll('.auth-screen').forEach(s=>s.classList.remove('active'));
+    for(let i=0;i<6;i++){const o=document.getElementById('o'+i);if(o)o.value='';}
     document.getElementById('lock-screen').classList.add('active');
   }
   if(document.hidden){
@@ -1332,7 +1339,7 @@ function goTo(sid,btn){if(appMode==='basic'&&ADVANCED_SCREENS.includes(sid)){sid
   else if(sid==='s-ayuda')renderAyuda();
   else if(sid==='s-proyeccion'){const el=document.getElementById('dca-base-display');if(el)el.textContent=fe(cV(activeId)||0);renderProyList();}
 }
-function renderQN(cur){['resumen','cartera','efectivo','ops','proyeccion','indices','notif','plataformas','rentabilidad','grupos','rent-efectivo','anotaciones','canales'].forEach(k=>{const el=document.getElementById('qn-'+k);if(!el)return;el.innerHTML=Object.entries(SL).filter(([id])=>id!==cur&&id!=='s-global'&&id!=='s-settings'&&id!=='s-perfil'&&id!=='s-ayuda'&&id!=='s-anotaciones'&&(appMode==='advanced'||!ADVANCED_SCREENS.includes(id))).map(([id,l])=>`<button class="qbtn" onclick="goTo('${id}')">${l}</button>`).join('');});}
+function renderQN(cur){const navIds=Object.keys(NM);['resumen','cartera','efectivo','ops','proyeccion','indices','notif','plataformas','rentabilidad','grupos','rent-efectivo','anotaciones','canales'].forEach(k=>{const el=document.getElementById('qn-'+k);if(!el)return;el.innerHTML=Object.entries(SL).filter(([id])=>id!==cur&&!navIds.includes(id)&&id!=='s-perfil'&&id!=='s-ayuda'&&(appMode==='advanced'||!ADVANCED_SCREENS.includes(id))).map(([id,l])=>`<button class="qbtn" onclick="goTo('${id}')">${l}</button>`).join('');});}
 function renderAyuda(){}
 function openModal(id){document.getElementById(id).classList.add('open');if(id==='m-portfolios')renderPortList();if(id==='m-op'||id==='m-efectivo')fillCS();}
 function closeModal(id){document.getElementById(id).classList.remove('open');}

--- a/prototype/manifest.json
+++ b/prototype/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "Portgrow",
+  "short_name": "Portgrow",
+  "description": "Gestión de carteras de inversión personal",
+  "start_url": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#1c1c1e",
+  "theme_color": "#1c1c1e"
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -39,3 +39,9 @@ const result = obfuscate(originalJs, {
 const obfuscatedHtml = html.replace(scriptRe, `<script>${result.getObfuscatedCode()}</script></body>`);
 fs.writeFileSync(out, obfuscatedHtml, 'utf8');
 console.log(`✓ dist/index.html generado (${Math.round(fs.statSync(out).size / 1024)} KB)`);
+
+const manifestSrc = path.join(__dirname, '..', 'prototype', 'manifest.json');
+if (fs.existsSync(manifestSrc)) {
+  fs.copyFileSync(manifestSrc, path.join(outDir, 'manifest.json'));
+  console.log('✓ dist/manifest.json copiado');
+}


### PR DESCRIPTION
## Fixes

| # | Bug | Solución |
|---|---|---|
| 1/2 | Quick-nav repite chips de la barra inferior | `renderQN` filtra `Object.keys(NM)` — solo muestra destinos que NO están en la nav bar |
| 3 | iPad: títulos del glosario centrados | `summary{text-align:left}` en CSS global |
| 4 | iPad: teclado OTP cambia a alfabético tras cada dígito | `inputmode="numeric" pattern="[0-9]*"` en los 6 inputs |
| 5 | Barra del navegador siempre visible | PWA manifest + meta tags iOS añadidos (ver nota abajo) |
| 6 | Al expirar sesión: pantalla OTP y lock screen superpuestas, dígitos visibles | `doLock()` limpia `.auth-screen` activos y borra dígitos OTP antes de mostrar el lock |

## Nota sobre #5 — barra del navegador

La barra solo desaparece cuando el usuario **instala la app** desde el navegador:
- **iOS Safari**: Compartir → Añadir a inicio
- **Android Chrome**: menú ⋮ → Instalar app / Añadir a pantalla de inicio

Sin ese paso, la barra siempre aparece — es una limitación de los navegadores web. El manifest ya está en su sitio; solo falta que los testers instalen la app.

## Archivos nuevos
- `prototype/manifest.json` — definición PWA (`display: standalone`, orientación portrait, colores del tema oscuro)
- `scripts/build.js` — copia manifest a `dist/` durante el build

## Test plan
- [ ] Quick-nav en cualquier pantalla: sin duplicados con la barra inferior
- [ ] Glosario en iPad: títulos alineados a la izquierda
- [ ] OTP en iPad: teclado numérico se mantiene entre dígitos
- [ ] Instalar app en móvil → abre sin barra del navegador
- [ ] Dejar app en segundo plano > 1 min → vuelve solo a pantalla de contraseña (sin OTP ni dígitos visibles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)