### PR TITLE
feat: añadir sección feedback en s-perfil con enlace mailto

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -745,6 +745,14 @@ input:focus,select:focus,textarea:focus{border-color:var(--ac);box-shadow:0 0 0 
       <div class="card" id="perfil-sesiones"></div>
       <div class="slabel" style="margin-top:12px;margin-bottom:7px">Plan</div>
       <div class="card" id="perfil-plan-card"></div>
+      <div class="slabel" style="margin-top:12px;margin-bottom:7px">Contacto y feedback</div>
+      <div class="card">
+        <div style="font-size:12px;color:var(--t1);margin-bottom:10px;line-height:1.5">¿Tienes una sugerencia, has encontrado un error o quieres proponer una mejora? Escríbenos.</div>
+        <a href="mailto:feedback@portgrow.com?subject=Feedback%20Portgrow" style="display:flex;align-items:center;gap:8px;padding:10px 12px;background:var(--bg1);border-radius:10px;text-decoration:none;color:var(--t0);font-size:13px;font-weight:600">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--ac)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M2 8l10 6 10-6"/></svg>
+          feedback@portgrow.com
+        </a>
+      </div>
       <div class="slabel" style="margin-top:12px;margin-bottom:7px">Zona de peligro</div>
       <button class="btn" style="color:var(--neg);border-color:var(--neg);margin-bottom:6px" onclick="if(confirm('¿Eliminar cuenta? Esta acción no se puede deshacer.'))resetAuth()">Eliminar cuenta</button>
       <button class="btn" onclick="resetAuth()">Cerrar sesión</button>


### PR DESCRIPTION
## Resumen

- Añade sección de feedback en la pantalla Perfil (s-perfil)
- Enlace mailto a feedback@portgrow.com con asunto prerellenado
- Visible antes de la zona de peligro

## Test plan

- [ ] Abrir s-perfil → ver sección de feedback
- [ ] Tap en el enlace → abre cliente de correo con asunto prerellenado

🤖 Generated with [Claude Code](https://claude.com/claude-code)