### PR TITLE
chore: Supabase CLI init + docs/SUPABASE.md

### DIFF
--- a/docs/SUPABASE.md
+++ b/docs/SUPABASE.md
@@ -1,0 +1,254 @@
+# Supabase — Setup y referencia operacional
+
+> Documento vivo. Actualizar cuando se ejecuten migraciones, se añadan proyectos o cambie la configuración.
+
+---
+
+## 1. Qué es Supabase y cómo encaja en Portgrow
+
+Supabase es el backend de Portgrow. Proporciona:
+
+| Servicio | Uso en Portgrow |
+|---|---|
+| **PostgreSQL** | Base de datos principal (modelo Kimball + 3NF) |
+| **Auth** | Autenticación de usuarios (email/password + 2FA) |
+| **RLS** (Row Level Security) | Cada usuario solo ve sus propios datos — se configura a nivel de BD |
+| **Edge Functions** | Lógica de servidor (Deno/TypeScript) sin backend propio |
+| **Realtime** | Subscripciones en tiempo real (para futuras notificaciones) |
+| **Storage** | Almacenamiento de archivos (backups, avatares) |
+
+**Local-first**: la app (React Native + WatermelonDB) trabaja offline y sincroniza contra Supabase cuando hay conexión.
+
+---
+
+## 2. Estructura de proyectos (entornos)
+
+| Proyecto | Referencia | Uso |
+|---|---|---|
+| `portapp` (renombrar a `portgrow-dev`) | `fteanipvydeaflfegldn` | Desarrollo e integración |
+| `portgrow-prod` (pendiente crear) | — | Producción |
+
+**Organización**: `portapp` en Supabase (org ID: `mximnbarzokxksvdwqyh`).
+
+El tier gratuito permite **2 proyectos por organización** — suficiente para dev + prod.
+
+> **Pendiente**: Crear el proyecto `portgrow-prod` en el dashboard cuando estemos listos para producción. URL: https://supabase.com/dashboard/org/mximnbarzokxksvdwqyh/projects
+
+---
+
+## 3. Setup realizado (paso a paso)
+
+### 3.1. Instalación de Scoop (gestor de paquetes Windows)
+
+Scoop es el equivalente a `brew` en macOS. Se instaló para poder instalar la CLI de Supabase sin necesitar permisos de administrador.
+
+```powershell
+# Ejecutado en PowerShell como usuario normal (no admin)
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+```
+
+Scoop se instala en `C:\Users\Admin\scoop\`.
+
+**Nota**: En sesiones nuevas de PowerShell/bash, Scoop no siempre está en el PATH. Si un comando `scoop` o `supabase` no se encuentra, añadir manualmente:
+```powershell
+$env:PATH += ';' + $env:USERPROFILE + '\scoop\shims'
+```
+
+### 3.2. Instalación de Supabase CLI
+
+```powershell
+scoop bucket add supabase https://github.com/supabase/scoop-bucket.git
+scoop install supabase
+```
+
+Versión instalada: **v2.95.4**. Para actualizar en el futuro: `scoop update supabase`.
+
+Verificar instalación:
+```powershell
+supabase --version
+```
+
+### 3.3. Autenticación
+
+```powershell
+supabase login --token <SUPABASE_ACCESS_TOKEN>
+```
+
+El token se genera en: https://supabase.com/dashboard/account/tokens
+
+**Importante**: 
+- Nunca pasar el token por `bash !` (el `$` se escapa mal). Usar siempre el PowerShell tool o el terminal directo.
+- Si el token se expone accidentalmente, revocarlo inmediatamente en el dashboard y generar uno nuevo.
+- El token se guarda en `C:\Users\Admin\.supabase\access-token` (archivo local, no en el repo).
+
+### 3.4. Inicialización del repositorio
+
+```powershell
+cd C:\Users\Admin\Documents\portapp
+supabase init
+```
+
+Crea:
+- `supabase/config.toml` — configuración del proyecto local
+- `supabase/.gitignore` — excluye `.temp/` del repo (contiene tokens y metadata local)
+
+### 3.5. Linking al proyecto remoto
+
+```powershell
+supabase link --project-ref fteanipvydeaflfegldn
+```
+
+Esto conecta el directorio local con el proyecto `portapp` en Supabase Cloud. Los datos de la conexión se guardan en `supabase/.temp/` (que está en `.gitignore`).
+
+---
+
+## 4. Archivos importantes
+
+### `supabase/config.toml`
+
+Configuración del entorno local de desarrollo. Los valores relevantes:
+
+```toml
+project_id = "portapp"          # identificador local
+
+[db]
+major_version = 17              # PostgreSQL 17 (igual que el proyecto remoto)
+
+[auth]
+site_url = "http://127.0.0.1:3000"   # cambiar a URL real en producción
+jwt_expiry = 3600               # tokens caducan en 1 hora
+enable_signup = true
+enable_anonymous_sign_ins = false
+
+[auth.email]
+enable_confirmations = false    # en dev no obliga a confirmar email
+```
+
+### `supabase/.gitignore`
+
+Excluye `.temp/` — que contiene el project-ref, tokens temporales y versiones de servicios. **No commitear esto nunca**.
+
+### `supabase/migrations/` (pendiente crear)
+
+Aquí irán los archivos `.sql` de migración numerados:
+```
+supabase/migrations/
+  20260502000000_initial_schema.sql
+  20260510000000_add_user_consents.sql
+  ...
+```
+
+---
+
+## 5. Comandos de referencia
+
+### Desarrollo local (requiere Docker — no disponible en este entorno)
+
+```powershell
+supabase start          # levanta Postgres + Auth + Studio localmente
+supabase stop           # para el entorno local
+supabase status         # URLs y claves del entorno local
+```
+
+> **Nota**: Docker Desktop no pudo instalarse en este equipo por restricciones de seguridad (el instalador exige que la carpeta de Docker Desktop sea propiedad de una cuenta elevada). **Decisión tomada**: trabajar directamente contra Supabase Cloud (portapp/portgrow-dev) en lugar de desarrollo local. Revisar si esto cambia cuando se migre a hardware distinto.
+
+### Gestión de migraciones
+
+```powershell
+# Crear nueva migración (genera archivo vacío con timestamp)
+supabase migration new nombre_de_la_migracion
+
+# Aplicar migraciones al proyecto remoto (linked)
+supabase db push
+
+# Ver estado de migraciones
+supabase migration list
+
+# Generar migración desde diff entre local y remoto
+supabase db diff --schema public
+```
+
+### Gestión de proyectos
+
+```powershell
+supabase projects list              # lista proyectos de la cuenta
+supabase link --project-ref <REF>   # cambia el proyecto linked
+
+# Para cambiar entre dev y prod:
+supabase link --project-ref fteanipvydeaflfegldn   # dev
+supabase link --project-ref <PROD_REF>              # prod (cuando exista)
+```
+
+### Edge Functions
+
+```powershell
+supabase functions new nombre-funcion     # crea nueva función
+supabase functions deploy nombre-funcion  # despliega al proyecto linked
+supabase functions list                   # lista funciones deployadas
+```
+
+### Auth y usuarios
+
+```powershell
+supabase auth export-users   # exporta usuarios (útil para migraciones)
+```
+
+---
+
+## 6. Conceptos clave
+
+### Row Level Security (RLS)
+
+RLS está **activado por defecto** en el proyecto. Significa que aunque la API esté expuesta públicamente, ningún usuario puede leer datos de otro usuario. Las políticas se definen en SQL:
+
+```sql
+-- Ejemplo: usuario solo ve sus propias carteras
+CREATE POLICY "users_own_carteras"
+ON public.carteras
+FOR ALL
+USING (auth.uid() = user_id);
+```
+
+Sin políticas, **con RLS activado, nadie puede leer nada** (tabla bloqueada por defecto). Crear siempre las políticas junto con las tablas.
+
+### Migraciones
+
+Supabase usa migraciones SQL ordenadas por timestamp. El flujo es:
+1. `supabase migration new <nombre>` — crea archivo vacío
+2. Escribir el SQL en el archivo
+3. `supabase db push` — aplica al remoto
+4. El historial queda en `supabase/migrations/` y se commitea al repo
+
+### Variables de entorno
+
+Las claves de Supabase **nunca van en el código**. En React Native (Expo), irán en `.env`:
+```
+EXPO_PUBLIC_SUPABASE_URL=https://fteanipvydeaflfegldn.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=eyJ...
+```
+
+La `anon key` es pública (puede estar en cliente). La `service_role key` es secreta y solo en servidor/Edge Functions.
+
+Ambas claves están en: https://supabase.com/dashboard/project/fteanipvydeaflfegldn/settings/api
+
+---
+
+## 7. Próximos pasos (pendiente feedback de testers avanzados)
+
+1. **Crear migración inicial** desde `docs/DATA_MODEL.md` — todas las tablas del modelo operacional + Kimball
+2. **Crear proyecto `portgrow-prod`** en el dashboard cuando el schema esté estable
+3. **Configurar RLS** — una política por tabla para `auth.uid() = user_id`
+4. **Tabla `user_consents`** — consentimientos GDPR (consent_type, version, timestamps)
+5. **Auth settings en prod**: activar confirmación de email, configurar SMTP (Resend/SendGrid)
+6. **Edge Functions**: primera función (p.ej. recálculo de métricas TWR)
+
+---
+
+## 8. Dashboard
+
+- Org: https://supabase.com/dashboard/org/mximnbarzokxksvdwqyh
+- Proyecto dev: https://supabase.com/dashboard/project/fteanipvydeaflfegldn
+- Table editor (dev): https://supabase.com/dashboard/project/fteanipvydeaflfegldn/editor
+- Auth (dev): https://supabase.com/dashboard/project/fteanipvydeaflfegldn/auth/users
+- SQL editor (dev): https://supabase.com/dashboard/project/fteanipvydeaflfegldn/sql

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,406 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "portapp"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"


### PR DESCRIPTION
## Qué incluye

- `supabase/config.toml` — configuración generada por `supabase init`, linked al proyecto `portapp` (portgrow-dev, ref: `fteanipvydeaflfegldn`, EU West)
- `supabase/.gitignore` — excluye `.temp/` y `.env.local` del repo
- `docs/SUPABASE.md` — documentación completa del setup: pasos realizados, comandos de referencia, conceptos clave (RLS, migraciones), próximos pasos y links al dashboard

## Qué NO incluye

- Migraciones (pendiente hasta que el feedback de testers avanzados confirme el modelo de datos)
- Credenciales ni tokens (el access token está en `~/.supabase/access-token`, fuera del repo)

## Test

No hay código ejecutable. Verificar que `supabase/config.toml` existe y `supabase/.temp/` no aparece en el PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)