### PR TITLE
docs: portapp→Portgrow, fix SPEC sections, Tarea 7 testers

### DIFF
--- a/docs/BUSINESS_PLAN.md
+++ b/docs/BUSINESS_PLAN.md
@@ -1,18 +1,18 @@
-# portapp — Documento de negocio para inversores
+# Portgrow — Documento de negocio para inversores
 
-> Versión 1.4 · Abril 2026 · Confidencial
+> Versión 1.5 · Mayo 2026 · Confidencial
 
 ---
 
 ## Resumen ejecutivo
 
-**portapp** es una aplicación móvil y web de gestión de carteras de inversión personal, diseñada para el inversor minorista hispanohablante que gestiona su patrimonio de forma autónoma. El mercado objetivo es España y Latinoamérica — un universo de más de **500 millones de hispanohablantes** donde la oferta de herramientas de inversión en español es prácticamente inexistente y la comunidad DIY (Do It Yourself) crece de forma acelerada.
+**Portgrow** es una aplicación móvil y web de gestión de carteras de inversión personal, diseñada para el inversor minorista hispanohablante que gestiona su patrimonio de forma autónoma. El mercado objetivo es España y Latinoamérica — un universo de más de **500 millones de hispanohablantes** donde la oferta de herramientas de inversión en español es prácticamente inexistente y la comunidad DIY (Do It Yourself) crece de forma acelerada.
 
-A diferencia de los competidores existentes, portapp adopta una arquitectura **local-first** que garantiza que los datos financieros del usuario nunca abandonan su dispositivo sin su consentimiento explícito — el único producto del mercado hispanohablante que combina privacidad real, funcionamiento offline completo y sincronización multi-dispositivo opcional.
+A diferencia de los competidores existentes, Portgrow adopta una arquitectura **local-first** que garantiza que los datos financieros del usuario nunca abandonan su dispositivo sin su consentimiento explícito — el único producto del mercado hispanohablante que combina privacidad real, funcionamiento offline completo y sincronización multi-dispositivo opcional.
 
 El mercado latinoamericano de fintech alcanzó **71.360 millones de dólares en 2024**, con más de 415 millones de usuarios de servicios financieros digitales y un crecimiento del 27% anual en financiación. En España, el número de carteras de inversores minoristas alcanzó las **551.000 en 2024**, con una rentabilidad media del 16,3% ese año, reflejo de una comunidad inversora madura y activa.
 
-portapp opera un modelo de monetización híbrido — pago único por la app base + suscripción anual por servicios con coste recurrente real + licencias B2B para asesores financieros — que combina bajas barreras de adquisición con ingresos recurrentes predecibles.
+Portgrow opera un modelo de monetización híbrido — pago único por la app base + suscripción anual por servicios con coste recurrente real + licencias B2B para asesores financieros — que combina bajas barreras de adquisición con ingresos recurrentes predecibles.
 
 El equipo busca una inversión inicial para completar el desarrollo del producto y ejecutar el lanzamiento en España, con expansión natural al mercado hispanohablante latinoamericano.
 
@@ -35,7 +35,7 @@ Los líderes del mercado (Sharesight, Snowball Analytics, Portfolio Performance)
 
 ## 2. La solución
 
-portapp es una aplicación iOS, Android y web que permite al inversor minorista:
+Portgrow es una aplicación iOS, Android y web que permite al inversor minorista:
 
 - **Consolidar** todas sus carteras en una sola vista — acciones, ETFs, criptomonedas, efectivo
 - **Analizar** su rentabilidad real con el método TWR (Time-Weighted Return), el estándar profesional
@@ -45,7 +45,7 @@ portapp es una aplicación iOS, Android y web que permite al inversor minorista:
 
 **Acceso a todos los mercados mundiales**
 
-Aunque el producto está diseñado para el inversor hispanohablante, soporta todos los mercados financieros globales — NASDAQ, NYSE, XETRA, Londres, Tokio, mercados emergentes y criptomonedas. El inversor hispanohablante opera en los mismos mercados internacionales que cualquier otro inversor: portapp no limita su acceso a ninguno de ellos.
+Aunque el producto está diseñado para el inversor hispanohablante, soporta todos los mercados financieros globales — NASDAQ, NYSE, XETRA, Londres, Tokio, mercados emergentes y criptomonedas. El inversor hispanohablante opera en los mismos mercados internacionales que cualquier otro inversor: Portgrow no limita su acceso a ninguno de ellos.
 
 **El diferenciador clave: privacidad por diseño**
 
@@ -57,7 +57,7 @@ La app está diseñada y desarrollada en español. No es una traducción — es 
 
 **Ecosistema educativo integrado**
 
-portapp no es solo una herramienta de seguimiento — es una plataforma de educación financiera. La app incluye acceso a canales de YouTube curados sobre inversión, y la estrategia de contenido se extiende fuera de la app con un **blog especializado** y **webinars periódicos** sobre estrategias de inversión, fiscalidad y gestión patrimonial. Este ecosistema educativo cumple tres funciones simultáneas: genera tráfico orgánico (SEO), crea comunidad y aumenta la retención — el usuario que aprende con portapp no tiene razón para irse a la competencia.
+Portgrow no es solo una herramienta de seguimiento — es una plataforma de educación financiera. La app incluye acceso a canales de YouTube curados sobre inversión, y la estrategia de contenido se extiende fuera de la app con un **blog especializado** y **webinars periódicos** sobre estrategias de inversión, fiscalidad y gestión patrimonial. Este ecosistema educativo cumple tres funciones simultáneas: genera tráfico orgánico (SEO), crea comunidad y aumenta la retención — el usuario que aprende con Portgrow no tiene razón para irse a la competencia.
 
 ---
 
@@ -89,7 +89,7 @@ México, Argentina y Colombia son los mercados más maduros de la región. El in
 
 ### Oportunidad específica
 
-La comunidad hispanohablante ha sido históricamente desatendida en el espacio de inversión. No existe ninguna aplicación de gestión de carteras en español con las capacidades de portapp. El mercado potencial total (TAM) en el segmento hispanohablante supera los 500 millones de personas, con un núcleo de inversores activos estimado en varios millones creciendo año a año.
+La comunidad hispanohablante ha sido históricamente desatendida en el espacio de inversión. No existe ninguna aplicación de gestión de carteras en español con las capacidades de Portgrow. El mercado potencial total (TAM) en el segmento hispanohablante supera los 500 millones de personas, con un núcleo de inversores activos estimado en varios millones creciendo año a año.
 
 ---
 
@@ -97,7 +97,7 @@ La comunidad hispanohablante ha sido históricamente desatendida en el espacio d
 
 ### Análisis competitivo
 
-| Competidor | Fortalezas | Debilidades vs. portapp |
+| Competidor | Fortalezas | Debilidades vs. Portgrow |
 |---|---|---|
 | **Sharesight** | 500.000+ usuarios globales, informes fiscales, marca consolidada | Solo en inglés, datos en servidores cloud, sin offline, $7-23/mes, sin soporte mercado español |
 | **Snowball Analytics** | Perspectiva europea, herramientas de optimización | Solo en inglés, datos en servidor, $12-15/mes |
@@ -108,7 +108,7 @@ La comunidad hispanohablante ha sido históricamente desatendida en el espacio d
 
 ### Ventaja competitiva sostenible
 
-portapp ocupa un espacio no disputado: **privacidad real + experiencia móvil fluida + español nativo**. Portfolio Performance es la única solución verdaderamente privada comparable, pero es exclusivamente desktop, no tiene versión móvil y requiere conocimientos técnicos avanzados. Ningún competidor actual combina los tres atributos simultáneamente para el mercado hispanohablante.
+Portgrow ocupa un espacio no disputado: **privacidad real + experiencia móvil fluida + español nativo**. Portfolio Performance es la única solución verdaderamente privada comparable, pero es exclusivamente desktop, no tiene versión móvil y requiere conocimientos técnicos avanzados. Ningún competidor actual combina los tres atributos simultáneamente para el mercado hispanohablante.
 
 ---
 
@@ -148,7 +148,7 @@ Asesores financieros independientes, family offices. Acceso de lectura a cartera
 
 ### Estado actual
 
-El **Prototipo v6** está completo y en pruebas con usuarios reales. Es un prototipo HTML autocontenido que valida flujos y experiencia de usuario, sin backend. Incluye 17 pantallas funcionales con modo básico/avanzado, proyecciones DCA guardadas, cancelación de operaciones y FAQ integrada.
+El **Prototipo v6** está completo — dos rondas de testers completadas. Es un prototipo HTML autocontenido que valida flujos y experiencia de usuario, sin backend. Incluye 18 pantallas funcionales con modo básico/avanzado, proyecciones DCA guardadas, cancelación de operaciones y FAQ integrada.
 
 ### Roadmap
 
@@ -163,7 +163,7 @@ El **Prototipo v6** está completo y en pruebas con usuarios reales. Es un proto
 ### Stack tecnológico
 
 - **Frontend:** React Native + Expo (iOS, Android y Web desde una base de código)
-- **Base de datos local:** Expo SQLite
+- **Base de datos local:** WatermelonDB (SQLite)
 - **Sincronización:** PowerSync / Electric SQL
 - **Backend:** Supabase (PostgreSQL, Auth, Storage, Edge Functions, RLS)
 - **Pagos:** Paddle (Merchant of Record — gestiona IVA y facturación)
@@ -176,7 +176,7 @@ El **Prototipo v6** está completo y en pruebas con usuarios reales. Es un proto
 
 ### Fortalezas
 
-- **Único producto profesional en español** — no existe ningún competidor con las capacidades de portapp en español. Es el primer entrante en un mercado desatendido.
+- **Único producto profesional en español** — no existe ningún competidor con las capacidades de Portgrow en español. Es el primer entrante en un mercado desatendido.
 - **Privacidad como diferenciador estructural** — arquitectura local-first que ningún competidor principal ofrece. No es marketing: los datos no pueden ser vendidos, hackeados del servidor ni cedidos a terceros.
 - **Funcionamiento offline completo** — el usuario consulta y registra operaciones sin conexión. Relevante en mercados latinoamericanos con conectividad variable.
 - **Comunidad hispanohablante ya educada** — existe un ecosistema maduro de blogs, podcasts y canales de YouTube sobre inversión en español (El Inversor Inteligente, Indexa Capital, Finect…) que genera demanda orgánica y facilita la distribución.
@@ -217,24 +217,24 @@ El **Prototipo v6** está completo y en pruebas con usuarios reales. Es un proto
 
 ## 8. Economic Moat — Barreras de entrada sostenibles
 
-Un moat económico es la ventaja competitiva duradera que protege a una empresa de la competencia a largo plazo. portapp tiene la capacidad de construir un moat sólido basado en cuatro fuentes combinadas:
+Un moat económico es la ventaja competitiva duradera que protege a una empresa de la competencia a largo plazo. Portgrow tiene la capacidad de construir un moat sólido basado en cuatro fuentes combinadas:
 
 **8.1 Switching costs — el moat más fuerte**
-Cuando un usuario lleva 12-24 meses registrando operaciones en portapp, ha acumulado un historial financiero completo e irreemplazable: compras, ventas, dividendos, rentabilidades, anotaciones. Migrar ese historial a otra app es costoso en tiempo y propenso a errores. Cuanto más tiempo usa el producto, más difícil es abandonarlo — exactamente lo contrario a la mayoría de apps de consumo.
+Cuando un usuario lleva 12-24 meses registrando operaciones en Portgrow, ha acumulado un historial financiero completo e irreemplazable: compras, ventas, dividendos, rentabilidades, anotaciones. Migrar ese historial a otra app es costoso en tiempo y propenso a errores. Cuanto más tiempo usa el producto, más difícil es abandonarlo — exactamente lo contrario a la mayoría de apps de consumo.
 
 **8.2 Content moat — comunidad como barrera**
-El blog, los webinars y los canales curados crean un ecosistema de contenido propio que los competidores no pueden replicar con dinero a corto plazo. Una comunidad activa de inversores hispanohablantes que asocia su formación financiera con portapp genera referidos orgánicos, reduce el coste de adquisición y aumenta la retención. Este moat crece con el tiempo y es muy difícil de copiar.
+El blog, los webinars y los canales curados crean un ecosistema de contenido propio que los competidores no pueden replicar con dinero a corto plazo. Una comunidad activa de inversores hispanohablantes que asocia su formación financiera con Portgrow genera referidos orgánicos, reduce el coste de adquisición y aumenta la retención. Este moat crece con el tiempo y es muy difícil de copiar.
 
 **8.3 Moat arquitectónico — privacidad irrepetible**
-La arquitectura local-first no es una característica que se añade a un producto existente — requiere rediseñar el producto desde cero. Los competidores establecidos (Sharesight, Snowball) tienen millones de usuarios en arquitecturas cloud y no pueden migrar sin romper su negocio actual. Este moat es especialmente defensivo porque convierte la fortaleza de portapp en la debilidad estructural de sus competidores.
+La arquitectura local-first no es una característica que se añade a un producto existente — requiere rediseñar el producto desde cero. Los competidores establecidos (Sharesight, Snowball) tienen millones de usuarios en arquitecturas cloud y no pueden migrar sin romper su negocio actual. Este moat es especialmente defensivo porque convierte la fortaleza de Portgrow en la debilidad estructural de sus competidores.
 
 **8.4 Network effects parciales**
 Las carteras compartidas, las comparativas anónimas entre usuarios y el contenido comunitario crean efectos de red moderados: cuantos más usuarios, más valor genera la plataforma para cada usuario individual. No es el network effect de una red social, pero sí un efecto de comunidad que se refuerza con el crecimiento.
 
 **8.5 Data moat — inteligencia acumulada**
-portapp captura desde el primer día métricas detalladas de comportamiento: qué pantallas usa cada tipo de usuario, qué activos registra, cómo navega, dónde abandona. Esta capa de analytics — inspirada en el modelo de instrumentación de los juegos móviles — genera una ventaja competitiva creciente: cada mes de operación añade señales que permiten optimizar el producto, personalizar la experiencia y afinar el marketing con una precisión que un competidor nuevo no puede replicar. Los datos acumulados son, en sí mismos, un activo que crece con el tiempo.
+Portgrow captura desde el primer día métricas detalladas de comportamiento: qué pantallas usa cada tipo de usuario, qué activos registra, cómo navega, dónde abandona. Esta capa de analytics — inspirada en el modelo de instrumentación de los juegos móviles — genera una ventaja competitiva creciente: cada mes de operación añade señales que permiten optimizar el producto, personalizar la experiencia y afinar el marketing con una precisión que un competidor nuevo no puede replicar. Los datos acumulados son, en sí mismos, un activo que crece con el tiempo.
 
-**Conclusión:** portapp no tiene un moat único y dominante como Google o Visa, pero sí una combinación de switching costs + content + arquitectura + datos que lo hace estructuralmente defensible. En el mercado hispanohablante, donde no existe ningún competidor establecido, construir ese moat antes que nadie es el objetivo central de los primeros 24 meses.
+**Conclusión:** Portgrow no tiene un moat único y dominante como Google o Visa, pero sí una combinación de switching costs + content + arquitectura + datos que lo hace estructuralmente defensible. En el mercado hispanohablante, donde no existe ningún competidor establecido, construir ese moat antes que nadie es el objetivo central de los primeros 24 meses.
 
 ---
 
@@ -296,11 +296,11 @@ El programa de financiación más potente de Europa para startups innovadoras. C
 - Presupuesto 2026: **414 millones de euros**
 - Convocatorias bimestrales (6 al año)
 
-Es altamente competitivo (~5% de éxito) y adecuado para cuando portapp tenga tracción demostrada — horizonte realista: **12–18 meses desde el lanzamiento**.
+Es altamente competitivo (~5% de éxito) y adecuado para cuando Portgrow tenga tracción demostrada — horizonte realista: **12–18 meses desde el lanzamiento**.
 
 ### Estrategia de financiación combinada
 
-La combinación óptima para portapp en su fase actual:
+La combinación óptima para Portgrow en su fase actual:
 
 ```
 Fase 1 (ahora):        ACCIÓ Startup Capital (75.000€ fondo perdido)
@@ -323,7 +323,7 @@ Tres tendencias convergen en este momento:
 La comunidad de inversión en español lleva años creciendo — canales de YouTube con 500.000+ seguidores, podcasts con decenas de miles de oyentes, foros activos. Todos ellos usan hojas de Excel o apps en inglés. La demanda está creada; el producto no existe.
 
 **2. Madurez tecnológica del local-first**
-Hace tres años, construir una app local-first con sync transparente requería implementar CRDTs desde cero. Hoy, PowerSync y Electric SQL abstraen esa complejidad. El momento técnico para construir portapp es ahora, con un coste de desarrollo significativamente menor que hace dos años.
+Hace tres años, construir una app local-first con sync transparente requería implementar CRDTs desde cero. Hoy, PowerSync y Electric SQL abstraen esa complejidad. El momento técnico para construir Portgrow es ahora, con un coste de desarrollo significativamente menor que hace dos años.
 
 **3. LatAm fintech en el mejor momento inversor de su historia**
 $4.100M invertidos en 2025, un 13,8% más que en 2024. El ecosistema latinoamericano de fintech está maduro, los inversores están activos y el mercado de usuarios fintech supera los 415 millones. Entrar ahora en España con visión de expansión latinoamericana es posicionarse en el momento de máximo crecimiento.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,4 +1,4 @@
-# portapp — Especificación de requisitos
+# Portgrow — Especificación de requisitos
 
 ## Visión general
 Gestor personal multicartera de activos financieros. Orientado a inversores particulares
@@ -26,7 +26,7 @@ movimientos de efectivo, proyecciones y rendimiento real.
 Campos por activo:
 - Ticker, ISIN, nombre completo del producto
 - Tipo: Acción | ETF | Cripto | Bono | Fondo | Otro
-- Índice que sigue (si aplica) — introducido automáticamente por la app a partir del ticker/ISIN
+- Índice que sigue (si aplica) — introducido manualmente en v1; automático a partir de ticker/ISIN en v2
 - Divisa de negociación
 - Mercado donde se negocia
 - Exposición porcentual por divisa y por región/país
@@ -52,8 +52,8 @@ Campos por operación:
 ### 5. Efectivo
 - Registro de ingresos: transferencia, Bizum, dividendo, staking, interés, saveback
 - Registro de egresos: compra activo, comisión, transferencia salida, otro
-- Saldo por broker con soporte multi-divisa
-- Conversión automática a divisa base
+- Saldo por broker *(multi-divisa en v2; v1 solo EUR)*
+- Conversión automática a divisa base *(v2)*
 
 ### 6. Proyección DCA
 - Aportación periódica configurable: semanal / quincenal / mensual
@@ -84,6 +84,27 @@ Agrupaciones predefinidas y personalizables:
 - Notas por activo individual (accesibles desde el detalle del activo)
 - No interfieren con el flujo ni la navegación
 
+### 11. Detalle de activo
+Pantalla individual por activo con:
+- Broker, fecha de compra, ticker, divisa
+- Cantidad comprada/vendida, comisión, coste total
+- Precio medio ponderado
+- Cotización actual *(v2; en v1 se introduce manualmente)*
+- Historial completo de operaciones
+- Anotaciones propias
+- Ajustes de reconciliación: corrección de precio medio, cantidad o saldo cuando difiere del broker
+- Conexión con todos los totales de la app
+
+### 12. Ajustes
+- Divisa base EUR *(multi-divisa en v2)*
+- Conexión con brokers y plataformas externas
+- Grupos de activos: crear, editar, eliminar
+- Preferencias de interfaz: modo oscuro, decimales, formato de fecha
+- Exportación: Excel, CSV
+- Importación de datos
+- Backup y restauración
+- Gestión de conexiones API *(v2)*
+
 ### 13. Rentabilidad efectivo (`s-rent-efectivo`)
 - Rentabilidad calculada sobre los movimientos de efectivo
 
@@ -94,27 +115,7 @@ Agrupaciones predefinidas y personalizables:
 - Canales de contenido curados para formación inversora
 
 ### 16. Ayuda / FAQ (`s-ayuda`)
-- Preguntas frecuentes, guía de uso, información sobre el cálculo de precio medio
-
-### 11. Detalle de activo
-Pantalla individual por activo con:
-- Broker, fecha de compra, ticker, divisa
-- Cantidad comprada/vendida, comisión, coste total
-- Precio medio ponderado
-- Cotización actual (API)
-- Historial completo de operaciones
-- Anotaciones propias
-- Conexión con todos los totales de la app
-
-### 12. Ajustes
-- Divisas activas y divisa base de conversión
-- Conexión con brokers y plataformas externas
-- Grupos de activos: crear, editar, eliminar
-- Preferencias de interfaz: modo oscuro, decimales, formato de fecha
-- Exportación: Excel, CSV
-- Importación de datos
-- Backup y restauración
-- Gestión de conexiones API
+- Preguntas frecuentes, guía de uso, información sobre el cálculo de precio medio y ajustes de reconciliación
 
 ---
 
@@ -156,7 +157,7 @@ Pantalla individual por activo con:
 
 | Versión | Contenido |
 |---------|-----------|
-| v6 (HTML) | Prototipo UI completo — 17 pantallas, modo básico/avanzado, proyecciones DCA (actual) |
+| v6 (HTML) | Prototipo UI completo — 18 pantallas, modo básico/avanzado, proyecciones DCA (actual) |
 | Prototipo 2 | Validación arquitectura local-first: React Native + WatermelonDB + Supabase |
 | v1.0 | App funcional con datos reales, sin APIs externas |
 | v1.5 | Integración cotizaciones en tiempo real |

--- a/docs/TEST_GUIDE.md
+++ b/docs/TEST_GUIDE.md
@@ -1,4 +1,4 @@
-# portapp — Guión de pruebas con usuarios
+# Portgrow — Guión de pruebas con usuarios
 
 > Credenciales demo: `usuario@portapp.com` / `demo1234` / OTP: `123456` *(simulado — no valida contra backend real)*
 > URL del prototipo: compartir via Netlify Drop
@@ -91,7 +91,7 @@ Entrega las tareas de una en una. No pases a la siguiente hasta que termine o se
 
 **Objetivo de la sesión:** Detectar funcionalidades que faltan, flujos que no son suficientemente potentes y comparaciones con herramientas que ya usan.
 
-**Duración estimada:** 40–50 minutos
+**Duración estimada:** 45–60 minutos
 
 ---
 
@@ -144,11 +144,17 @@ Entrega las tareas de una en una. No pases a la siguiente hasta que termine o se
 - Objetivo: probar los ajustes.
 - Señal de problema: no encuentra Ajustes o la configuración de seguridad.
 
+**Tarea 7 — Ajuste de reconciliación**
+> "El precio medio de VWCE en la app es 107,80€ pero tu broker muestra 108,20€ porque hay una comisión de custodia que no registraste. ¿Cómo lo corriges sin borrar el historial de operaciones?"
+
+- Objetivo: probar el flujo completo de ajuste de reconciliación (requiere modo avanzado).
+- Señal de problema: no encuentra el botón "+ Registrar ajuste" en el detalle del activo, confunde el ajuste con crear una nueva operación, no entiende por qué no se modifica el historial.
+
 ---
 
 ### Fase 3 — Preguntas al finalizar (10–15 min)
 
-1. ¿Qué herramienta usas ahora para seguir tus inversiones? ¿Qué tiene que portapp no tiene? ¿Y al revés?
+1. ¿Qué herramienta usas ahora para seguir tus inversiones? ¿Qué tiene que Portgrow no tiene? ¿Y al revés?
 2. ¿Hay algún cálculo o dato que esperabas ver y no estaba?
 3. ¿El cálculo de rentabilidad TWR te parece correcto o hay algo que no cuadra?
 4. ¿Pagarías por esta app? ¿Cuánto? ¿Pago único o suscripción?
@@ -173,6 +179,7 @@ Tarea 3: [completó / no completó] — Tiempo: __ min — Notas:
 Tarea 4: [completó / no completó] — Tiempo: __ min — Notas:
 Tarea 5: [completó / no completó] — Tiempo: __ min — Notas:
 Tarea 6 (solo B): [completó / no completó] — Tiempo: __ min — Notas:
+Tarea 7 (solo B): [completó / no completó] — Tiempo: __ min — Notas:
 
 MOMENTOS DE CONFUSIÓN (anotar literalmente qué dijo el usuario)
 -


### PR DESCRIPTION
## Cambios

### SPEC.md
- Renombrado a Portgrow
- Secciones reordenadas: 11 y 12 (Detalle activo y Ajustes) ahora aparecen antes de 13-16, como corresponde
- Notas v2 añadidas: multi-divisa, cotización automática, gestión de conexiones API
- Ajustes de reconciliación añadidos como feature de la sección 11
- 17 → 18 pantallas

### BUSINESS_PLAN.md
- Renombrado a Portgrow en todo el documento
- Versión 1.4 → 1.5, Abril → Mayo 2026
- Estado actual: 17 → 18 pantallas, "dos rondas de testers completadas"
- Stack: Expo SQLite → WatermelonDB (SQLite)

### TEST_GUIDE.md
- Renombrado a Portgrow
- **Nueva Tarea 7 para Perfil B**: ajuste de reconciliación (corrección de precio medio sin borrar historial)
- Duración estimada actualizada: 40-50 → 45-60 min
- Checklist actualizado con Tarea 7

## Nota
La guía de uso (`s-ayuda`) ya tenía los pasos para ajustes de reconciliación (FAQ línea 647 del prototipo). Lo que faltaba era la tarea de test en TEST_GUIDE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)